### PR TITLE
Fix @coroutine for functions without __name__

### DIFF
--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -162,7 +162,7 @@ class Future:
             cb = ''
 
         def format_cb(callback):
-            return events._format_callback(callback, ())
+            return events._format_callback_source(callback, ())
 
         if size == 1:
             cb = format_cb(cb[0])


### PR DESCRIPTION
Issue #222: Fix the @coroutine decorator for functions without __name__
attribute like functools.partial().

Enhance also the representation of a CoroWrapper if the coroutine
function is a functools.partial().