### PR TITLE
Add a mechanism in `create_server` to set custom socket options

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -804,7 +804,8 @@ class BaseEventLoop(events.AbstractEventLoop):
                       sock=None,
                       backlog=100,
                       ssl=None,
-                      reuse_address=None):
+                      reuse_address=None,
+                      sock_config_cb=lambda sock: None):
         """Create a TCP server.
 
         The host parameter can be a string, in that case the TCP server is bound
@@ -866,6 +867,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(socket.IPPROTO_IPV6,
                                         socket.IPV6_V6ONLY,
                                         True)
+                    sock_config_cb(sock)
                     try:
                         sock.bind(sa)
                     except OSError as err:


### PR DESCRIPTION
Sometimes you need to set some socket options before the socket is bound (e.g. `SO_REUSEPORT` on Linux 3.9+). I think `asyncio` should provide a mechanism by which this could be done using the `create_server` coroutine.

I know I could manually create the socket, set any options and then pass it in to `create_server`, but this would involve writing all the `getaddrinfo` logic again. I would also be limited to just one socket.
I also don't think adding another argument like `reuse_port` is the right way to go. It might solve the `SO_REUSEPORT`, but provides no other way to set other options.

My solution is to provide a callback function as an argument to `create_server` that will be called with a socket just before it is bound. This callback has the signature `f(sock)` and it's return value is ignored. The best name that I could think of for the argument was `sock_config_cb`, but if that's not clear it should probably be changed.

If there is a better way of setting options before the socket is bound, please do tell.