### PR TITLE
Fix queues

### DIFF
--- a/asyncio/queues.py
+++ b/asyncio/queues.py
@@ -132,10 +132,9 @@ class Queue:
             self._putters.append(putter)
             try:
                 yield from putter
-            except (futures.CancelledError, futures.TimeoutError):
-                if not putter.done():
-                    putter.cancel()
-                elif not putter.cancelled():
+            except:
+                putter.cancel()
+                if not self.full() and not putter.cancelled():
                     self._wakeup_next(self._putters)
                 raise
         return self.put_nowait(item)
@@ -165,10 +164,9 @@ class Queue:
             self._getters.append(getter)
             try:
                 yield from getter
-            except (futures.CancelledError, futures.TimeoutError):
-                if not getter.done():
-                    getter.cancel()
-                elif not getter.cancelled():
+            except:
+                getter.cancel()
+                if not self.empty() and not getter.cancelled():
                     self._wakeup_next(self._getters)
                 raise
         return self.get_nowait()

--- a/asyncio/queues.py
+++ b/asyncio/queues.py
@@ -133,8 +133,10 @@ class Queue:
             try:
                 yield from putter
             except:
-                putter.cancel()
+                putter.cancel()  # Just in case putter is not done yet.
                 if not self.full() and not putter.cancelled():
+                    # We were woken up by get_nowait(), but can't take
+                    # the call.  Wake up the next in line.
                     self._wakeup_next(self._putters)
                 raise
         return self.put_nowait(item)
@@ -165,8 +167,10 @@ class Queue:
             try:
                 yield from getter
             except:
-                getter.cancel()
+                getter.cancel()  # Just in case getter is not done yet.
                 if not self.empty() and not getter.cancelled():
+                    # We were woken up by put_nowait(), but can't take
+                    # the call.  Wake up the next in line.
                     self._wakeup_next(self._getters)
                 raise
         return self.get_nowait()

--- a/tests/test_queues.py
+++ b/tests/test_queues.py
@@ -479,6 +479,52 @@ class QueuePutTests(_QueueTestBase):
         self.loop.run_until_complete(q.put('a'))
         self.assertEqual(self.loop.run_until_complete(t), 'a')
 
+    def test_why_are_getters_waiting(self):
+        # From issue #268.
+
+        @asyncio.coroutine
+        def consumer(queue, num_expected):
+            for _ in range(num_expected):
+                yield from queue.get()
+
+        @asyncio.coroutine
+        def producer(queue, num_items):
+            for i in range(num_items):
+                yield from queue.put(i)
+
+        queue_size = 1
+        producer_num_items = 5
+        q = asyncio.Queue(queue_size, loop=self.loop)
+
+        self.loop.run_until_complete(
+            asyncio.gather(producer(q, producer_num_items),
+                           consumer(q, producer_num_items),
+                           loop=self.loop),
+            )
+
+    def test_why_are_putters_waiting(self):
+        # From issue #265.
+
+        queue = asyncio.Queue(2, loop=self.loop)
+
+        @asyncio.coroutine
+        def putter(item):
+            yield from queue.put(item)
+
+        @asyncio.coroutine
+        def getter():
+            yield
+            num = queue.qsize()
+            for _ in range(num):
+                item = queue.get_nowait()
+
+        t0 = putter(0)
+        t1 = putter(1)
+        t2 = putter(2)
+        t3 = putter(3)
+        self.loop.run_until_complete(
+            asyncio.gather(getter(), t0, t1, t2, t3, loop=self.loop))
+
 
 class LifoQueueTests(_QueueTestBase):
 

--- a/tests/test_queues.py
+++ b/tests/test_queues.py
@@ -271,6 +271,29 @@ class QueueGetTests(_QueueTestBase):
         self.assertEqual(self.loop.run_until_complete(q.get()), 'a')
         self.assertEqual(self.loop.run_until_complete(q.get()), 'b')
 
+    def test_why_are_getters_waiting(self):
+        # From issue #268.
+
+        @asyncio.coroutine
+        def consumer(queue, num_expected):
+            for _ in range(num_expected):
+                yield from queue.get()
+
+        @asyncio.coroutine
+        def producer(queue, num_items):
+            for i in range(num_items):
+                yield from queue.put(i)
+
+        queue_size = 1
+        producer_num_items = 5
+        q = asyncio.Queue(queue_size, loop=self.loop)
+
+        self.loop.run_until_complete(
+            asyncio.gather(producer(q, producer_num_items),
+                           consumer(q, producer_num_items),
+                           loop=self.loop),
+            )
+
 
 class QueuePutTests(_QueueTestBase):
 
@@ -377,13 +400,8 @@ class QueuePutTests(_QueueTestBase):
 
         loop.run_until_complete(reader3)
 
-        # reader2 will receive `2`, because it was added to the
-        # queue of pending readers *before* put_nowaits were called.
-        self.assertEqual(reader2.result(), 2)
-        # reader3 will receive `1`, because reader1 was cancelled
-        # before is had a chance to execute, and `2` was already
-        # pushed to reader2 by second `put_nowait`.
-        self.assertEqual(reader3.result(), 1)
+        # It is undefined in which order concurrent readers receive results.
+        self.assertEqual({reader2.result(), reader3.result()}, {1, 2})
 
     def test_put_cancel_drop(self):
 
@@ -478,29 +496,6 @@ class QueuePutTests(_QueueTestBase):
         test_utils.run_briefly(self.loop)
         self.loop.run_until_complete(q.put('a'))
         self.assertEqual(self.loop.run_until_complete(t), 'a')
-
-    def test_why_are_getters_waiting(self):
-        # From issue #268.
-
-        @asyncio.coroutine
-        def consumer(queue, num_expected):
-            for _ in range(num_expected):
-                yield from queue.get()
-
-        @asyncio.coroutine
-        def producer(queue, num_items):
-            for i in range(num_items):
-                yield from queue.put(i)
-
-        queue_size = 1
-        producer_num_items = 5
-        q = asyncio.Queue(queue_size, loop=self.loop)
-
-        self.loop.run_until_complete(
-            asyncio.gather(producer(q, producer_num_items),
-                           consumer(q, producer_num_items),
-                           loop=self.loop),
-            )
 
     def test_why_are_putters_waiting(self):
         # From issue #265.


### PR DESCRIPTION
This fixes both #265 and #265 (I have tests that repro each).

The implementation no longer uses the getter and putter futures to pass items around -- instead they are used to implement a simple condition variable, without the locking (which isn't needed because asyncio guarantees that no other tasks run until you use yield from).

When a new item is added to the queue, *all* getters are woken up, and they all just check whether there is an item for them. Similar for putters (the code is entirely symmetrical except for the unfinished tasks management).

This may look inefficient when there are many getters (or many putters) but there is much less code, and it is easier to understand its correctness. I think that is more important given the history of this code.

I had to fix one test, because when there are multiple concurrent getters, we don't guarantee the order in which they get items. That seems reasonable.