### PR TITLE
Rewrite Semaphore.acquire/release

### DIFF
--- a/asyncio/locks.py
+++ b/asyncio/locks.py
@@ -443,17 +443,17 @@ class Semaphore(_ContextManagerMixin):
         try:
             yield from fut
             self._value -= 1
+            self._num_ready -= 1
             return True
         except futures.CancelledError:
-            if self._value > 0:
+            if not fut.cancelled():
+                self._num_ready -= 1
                 self._wake_up_next()
             # `test_acquire_cancel` in tests/test_locks.py doesn't allow
             # cancelled waiters left in self._waiters
             if fut in self._waiters:
                 self._waiters.remove(fut)
             raise
-        finally:
-            self._num_ready -= 1
 
     def release(self):
         """Release a semaphore, incrementing the internal counter by one.

--- a/asyncio/locks.py
+++ b/asyncio/locks.py
@@ -432,12 +432,13 @@ class Semaphore(_ContextManagerMixin):
         called release() to make it larger than 0, and then return
         True.
         """
-        while self._value == 0:
+        while self._value <= 0:
             fut = futures.Future(loop=self._loop)
             self._waiters.append(fut)
             try:
                 yield from fut
             except:
+                # See the similar code in Queue.get.
                 fut.cancel()
                 if self._value > 0 and not fut.cancelled():
                     self._wake_up_next()

--- a/asyncio/locks.py
+++ b/asyncio/locks.py
@@ -434,7 +434,7 @@ class Semaphore(_ContextManagerMixin):
         called release() to make it larger than 0, and then return
         True.
         """
-        if not self._num_ready and self._value > 0:
+        if self._value - self._num_ready > 0:
             self._value -= 1
             return True
 

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -17,6 +17,7 @@ RGX_REPR = re.compile(STR_RGX_REPR)
 
 
 class LockTests(test_utils.TestCase):
+
     def setUp(self):
         self.loop = self.new_test_loop()
 
@@ -232,6 +233,7 @@ class LockTests(test_utils.TestCase):
 
 
 class EventTests(test_utils.TestCase):
+
     def setUp(self):
         self.loop = self.new_test_loop()
 
@@ -360,6 +362,7 @@ class EventTests(test_utils.TestCase):
 
 
 class ConditionTests(test_utils.TestCase):
+
     def setUp(self):
         self.loop = self.new_test_loop()
 

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -811,6 +811,21 @@ class SemaphoreTests(test_utils.TestCase):
             self.loop.run_until_complete, acquire)
         self.assertFalse(sem._waiters)
 
+    def test_acquire_hang(self):
+        sem = asyncio.Semaphore(value=0, loop=self.loop)
+
+        t1 = asyncio.Task(sem.acquire(), loop=self.loop)
+        t2 = asyncio.Task(sem.acquire(), loop=self.loop)
+
+        test_utils.run_briefly(self.loop)
+
+        sem.release()
+        t1.cancel()
+
+        test_utils.run_briefly(self.loop)
+        self.assertTrue(sem.locked())
+
+
     def test_release_not_acquired(self):
         sem = asyncio.BoundedSemaphore(loop=self.loop)
 


### PR DESCRIPTION
For #270

Add a failing test for original Semaphore: when a ready waiter be cancelled, the other pending waiters will not aware of it.

* `test_acquire` in tests/test_locks.py assumes that if *task A* calls `semaphore.acquire()` before *task B*, *A* will acquire the semaphore before *B*. I use `self._num_ready` to make sure that if there is any awoken waiter, the new `acquire` will not cut in line.
* `test_acquire_cancel` in tests/test_locks.py doesn't allow `Semaphore` to leaving cancelled waiters in `Semaphore._waiters`.

I'm not sure whether or not these two tests should be modified.