### PR TITLE
Make peer PID available via transport.get_extra_info for UNIX domain sockets

### DIFF
--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -514,6 +514,8 @@ class _SelectorTransport(transports._FlowControlMixin,
                 self._extra['peername'] = sock.getpeername()
             except socket.error:
                 self._extra['peername'] = None
+        if sock.family == socket.AF_UNIX:
+            self._extra['peercred'] = sock.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED)
         self._sock = sock
         self._sock_fd = sock.fileno()
         self._protocol = protocol


### PR DESCRIPTION
It wasn't obvious how to get connected peer's PID. get_extra_info('peername') returns empty bytes object.