### PR TITLE
Cleanup Future API

### DIFF
--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -20,7 +20,7 @@ _CANCELLED = 'CANCELLED'
 _FINISHED = 'FINISHED'
 
 Error = concurrent.futures._base.Error
-CancelledError = concurrent.futures._base.CancelledError
+CancelledError = concurrent.futures.CancelledError
 TimeoutError = concurrent.futures.TimeoutError
 
 STACK_DEBUG = logging.DEBUG - 1  # heavy-duty debugging
@@ -154,7 +154,7 @@ class Future:
         if self._loop.get_debug():
             self._source_traceback = traceback.extract_stack(sys._getframe(1))
 
-    def _format_callbacks(self):
+    def __format_callbacks(self):
         # Private method, do not rely on its existence.
         cb = self._callbacks
         size = len(cb)
@@ -186,7 +186,7 @@ class Future:
                 result = reprlib.repr(self._result)
                 info.append('result={}'.format(result))
         if self._callbacks:
-            info.append(self._format_callbacks())
+            info.append(self.__format_callbacks())
         if self._source_traceback:
             frame = self._source_traceback[-1]
             info.append('created at %s:%s' % (frame[0], frame[1]))
@@ -355,8 +355,6 @@ class Future:
             # have had a chance to call result() or exception().
             self._loop.call_soon(self._tb_logger.activate)
 
-    # Truly internal methods.
-
     def __iter__(self):
         if not self.done():
             self._blocking = True
@@ -390,7 +388,7 @@ def _set_concurrent_future_state(concurrent, source):
         concurrent.set_result(result)
 
 
-def _apply_future_state(source, dest):
+def _copy_future_state(source, dest):
     """Internal helper to copy state from another Future.
 
     The other Future may be a concurrent.futures.Future.
@@ -426,7 +424,7 @@ def _chain_future(source, destination):
 
     def _set_state(future, other):
         if isinstance(future, Future):
-            _apply_future_state(other, future)
+            _copy_future_state(other, future)
         else:
             _set_concurrent_future_state(future, other)
 

--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -175,6 +175,7 @@ class Future:
         return 'cb=[%s]' % cb
 
     def _repr_info(self):
+        # Private method, do not rely on its existence.
         info = [self._state.lower()]
         if self._state == _FINISHED:
             if self._exception is not None:
@@ -321,12 +322,6 @@ class Future:
 
     # So-called internal methods (note: no set_running_or_notify_cancel()).
 
-    def _set_result_unless_cancelled(self, result):
-        """Helper setting the result only if the future was not cancelled."""
-        if self.cancelled():
-            return
-        self.set_result(result)
-
     def set_result(self, result):
         """Mark the future done and set its result.
 
@@ -371,6 +366,13 @@ class Future:
 
     if compat.PY35:
         __await__ = __iter__ # make compatible with 'await' expression
+
+
+def _set_result_unless_cancelled(fut, result):
+    """Helper setting the result only if the future was not cancelled."""
+    if fut.cancelled():
+        return
+    fut.set_result(result)
 
 
 def _set_concurrent_future_state(concurrent, source):

--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -155,7 +155,7 @@ class Future:
             self._source_traceback = traceback.extract_stack(sys._getframe(1))
 
     def __format_callbacks(self):
-        # Private method, do not rely on its existence.
+        # Private to the asyncio module; unsafe to use in subclasses.
         cb = self._callbacks
         size = len(cb)
         if not size:
@@ -175,7 +175,7 @@ class Future:
         return 'cb=[%s]' % cb
 
     def _repr_info(self):
-        # Private method, do not rely on its existence.
+        # Private to the asyncio module; unsafe to use in subclasses.
         info = [self._state.lower()]
         if self._state == _FINISHED:
             if self._exception is not None:
@@ -230,7 +230,7 @@ class Future:
         return True
 
     def _schedule_callbacks(self):
-        # Private method, do not rely on its existence.
+        # Private to the asyncio module; unsafe to use in subclasses.
         """Internal: Ask the event loop to call all callbacks.
 
         The callbacks are scheduled to be called as soon as possible. Also

--- a/asyncio/proactor_events.py
+++ b/asyncio/proactor_events.py
@@ -41,7 +41,8 @@ class _ProactorBasePipeTransport(transports._FlowControlMixin,
         self._loop.call_soon(self._protocol.connection_made, self)
         if waiter is not None:
             # only wake up the waiter when connection_made() has been called
-            self._loop.call_soon(waiter._set_result_unless_cancelled, None)
+            self._loop.call_soon(futures._set_result_unless_cancelled,
+                                 waiter, None)
 
     def __repr__(self):
         info = [self.__class__.__name__]

--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -633,7 +633,8 @@ class _SelectorSocketTransport(_SelectorTransport):
                              self._sock_fd, self._read_ready)
         if waiter is not None:
             # only wake up the waiter when connection_made() has been called
-            self._loop.call_soon(waiter._set_result_unless_cancelled, None)
+            self._loop.call_soon(futures._set_result_unless_cancelled,
+                                 waiter, None)
 
     def pause_reading(self):
         if self._closing:
@@ -987,7 +988,8 @@ class _SelectorDatagramTransport(_SelectorTransport):
                              self._sock_fd, self._read_ready)
         if waiter is not None:
             # only wake up the waiter when connection_made() has been called
-            self._loop.call_soon(waiter._set_result_unless_cancelled, None)
+            self._loop.call_soon(futures._set_result_unless_cancelled,
+                                 waiter, None)
 
     def get_write_buffer_size(self):
         return sum(len(data) for data, _ in self._buffer)

--- a/asyncio/tasks.py
+++ b/asyncio/tasks.py
@@ -93,6 +93,7 @@ class Task(futures.Future):
             futures.Future.__del__(self)
 
     def _repr_info(self):
+        # Private to the asyncio module; unsafe to use in subclasses.
         info = super()._repr_info()
 
         if self._must_cancel:
@@ -221,6 +222,7 @@ class Task(futures.Future):
         return True
 
     def _step(self, value=None, exc=None):
+        # Private to the asyncio module; unsafe to use in subclasses.
         assert not self.done(), \
             '_step(): already done: {!r}, {!r}, {!r}'.format(self, value, exc)
         if self._must_cancel:
@@ -284,6 +286,7 @@ class Task(futures.Future):
             self = None  # Needed to break cycles when an exception occurs.
 
     def _wakeup(self, future):
+        # Private to the asyncio module; unsafe to use in subclasses.
         try:
             value = future.result()
         except Exception as exc:

--- a/asyncio/tasks.py
+++ b/asyncio/tasks.py
@@ -494,7 +494,8 @@ def sleep(delay, result=None, *, loop=None):
 
     future = futures.Future(loop=loop)
     h = future._loop.call_later(delay,
-                                future._set_result_unless_cancelled, result)
+                                futures._set_result_unless_cancelled,
+                                future, result)
     try:
         return (yield from future)
     finally:

--- a/asyncio/tasks.py
+++ b/asyncio/tasks.py
@@ -26,12 +26,12 @@ class Task(futures.Future):
 
     # An important invariant maintained while a Task not done:
     #
-    # - Either _fut_waiter is None, and __step() is scheduled;
-    # - or _fut_waiter is some Future, and __step() is *not* scheduled.
+    # - Either _fut_waiter is None, and _step() is scheduled;
+    # - or _fut_waiter is some Future, and _step() is *not* scheduled.
     #
     # The only transition from the latter to the former is through
-    # __wakeup().  When _fut_waiter is not None, one of its callbacks
-    # must be __wakeup().
+    # _wakeup().  When _fut_waiter is not None, one of its callbacks
+    # must be _wakeup().
 
     # Weak set containing all tasks alive.
     _all_tasks = weakref.WeakSet()
@@ -74,7 +74,7 @@ class Task(futures.Future):
         self._coro = coro
         self._fut_waiter = None
         self._must_cancel = False
-        self._loop.call_soon(self.__step)
+        self._loop.call_soon(self._step)
         self.__class__._all_tasks.add(self)
 
     # On Python 3.3 or older, objects with a destructor that are part of a
@@ -217,14 +217,14 @@ class Task(futures.Future):
                 # catches and ignores the cancellation so we may have
                 # to cancel it again later.
                 return True
-        # It must be the case that self.__step is already scheduled.
+        # It must be the case that self._step is already scheduled.
         self._must_cancel = True
         return True
 
-    def __step(self, value=None, exc=None):
+    def _step(self, value=None, exc=None):
         # Private to the asyncio module; unsafe to use in subclasses.
         assert not self.done(), \
-            '__step(): already done: {!r}, {!r}, {!r}'.format(self, value, exc)
+            '_step(): already done: {!r}, {!r}, {!r}'.format(self, value, exc)
         if self._must_cancel:
             if not isinstance(exc, futures.CancelledError):
                 exc = futures.CancelledError()
@@ -253,24 +253,24 @@ class Task(futures.Future):
                 # Yielded Future must come from Future.__iter__().
                 if result._blocking:
                     result._blocking = False
-                    result.add_done_callback(self.__wakeup)
+                    result.add_done_callback(self._wakeup)
                     self._fut_waiter = result
                     if self._must_cancel:
                         if self._fut_waiter.cancel():
                             self._must_cancel = False
                 else:
                     self._loop.call_soon(
-                        self.__step, None,
+                        self._step, None,
                         RuntimeError(
                             'yield was used instead of yield from '
                             'in task {!r} with {!r}'.format(self, result)))
             elif result is None:
                 # Bare yield relinquishes control for one event loop iteration.
-                self._loop.call_soon(self.__step)
+                self._loop.call_soon(self._step)
             elif inspect.isgenerator(result):
                 # Yielding a generator is just wrong.
                 self._loop.call_soon(
-                    self.__step, None,
+                    self._step, None,
                     RuntimeError(
                         'yield was used instead of yield from for '
                         'generator in task {!r} with {}'.format(
@@ -278,22 +278,22 @@ class Task(futures.Future):
             else:
                 # Yielding something else is an error.
                 self._loop.call_soon(
-                    self.__step, None,
+                    self._step, None,
                     RuntimeError(
                         'Task got bad yield: {!r}'.format(result)))
         finally:
             self.__class__._current_tasks.pop(self._loop)
             self = None  # Needed to break cycles when an exception occurs.
 
-    def __wakeup(self, future):
+    def _wakeup(self, future):
         # Private to the asyncio module; unsafe to use in subclasses.
         try:
             value = future.result()
         except Exception as exc:
             # This may also be a cancellation.
-            self.__step(None, exc)
+            self._step(None, exc)
         else:
-            self.__step(value, None)
+            self._step(value, None)
         self = None  # Needed to break cycles when an exception occurs.
 
 

--- a/asyncio/unix_events.py
+++ b/asyncio/unix_events.py
@@ -319,7 +319,8 @@ class _UnixReadPipeTransport(transports.ReadTransport):
                              self._fileno, self._read_ready)
         if waiter is not None:
             # only wake up the waiter when connection_made() has been called
-            self._loop.call_soon(waiter._set_result_unless_cancelled, None)
+            self._loop.call_soon(futures._set_result_unless_cancelled,
+                                 waiter, None)
 
     def __repr__(self):
         info = [self.__class__.__name__]
@@ -439,7 +440,8 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
 
         if waiter is not None:
             # only wake up the waiter when connection_made() has been called
-            self._loop.call_soon(waiter._set_result_unless_cancelled, None)
+            self._loop.call_soon(futures._set_result_unless_cancelled,
+                                 waiter, None)
 
     def __repr__(self):
         info = [self.__class__.__name__]

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -174,11 +174,13 @@ class FutureTests(test_utils.TestCase):
                          '<Future cancelled>')
 
     def test_copy_state(self):
+        from asyncio.futures import _apply_future_state
+
         f = asyncio.Future(loop=self.loop)
         f.set_result(10)
 
         newf = asyncio.Future(loop=self.loop)
-        newf._copy_state(f)
+        _apply_future_state(f, newf)
         self.assertTrue(newf.done())
         self.assertEqual(newf.result(), 10)
 
@@ -186,7 +188,7 @@ class FutureTests(test_utils.TestCase):
         f_exception.set_exception(RuntimeError())
 
         newf_exception = asyncio.Future(loop=self.loop)
-        newf_exception._copy_state(f_exception)
+        _apply_future_state(f_exception, newf_exception)
         self.assertTrue(newf_exception.done())
         self.assertRaises(RuntimeError, newf_exception.result)
 
@@ -194,7 +196,7 @@ class FutureTests(test_utils.TestCase):
         f_cancelled.cancel()
 
         newf_cancelled = asyncio.Future(loop=self.loop)
-        newf_cancelled._copy_state(f_cancelled)
+        _apply_future_state(f_cancelled, newf_cancelled)
         self.assertTrue(newf_cancelled.cancelled())
 
     def test_iter(self):

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -384,9 +384,10 @@ class FutureTests(test_utils.TestCase):
         self.check_future_exception_never_retrieved(True)
 
     def test_set_result_unless_cancelled(self):
+        from asyncio import futures
         fut = asyncio.Future(loop=self.loop)
         fut.cancel()
-        fut._set_result_unless_cancelled(2)
+        futures._set_result_unless_cancelled(fut, 2)
         self.assertTrue(fut.cancelled())
 
 

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -174,13 +174,13 @@ class FutureTests(test_utils.TestCase):
                          '<Future cancelled>')
 
     def test_copy_state(self):
-        from asyncio.futures import _apply_future_state
+        from asyncio.futures import _copy_future_state
 
         f = asyncio.Future(loop=self.loop)
         f.set_result(10)
 
         newf = asyncio.Future(loop=self.loop)
-        _apply_future_state(f, newf)
+        _copy_future_state(f, newf)
         self.assertTrue(newf.done())
         self.assertEqual(newf.result(), 10)
 
@@ -188,7 +188,7 @@ class FutureTests(test_utils.TestCase):
         f_exception.set_exception(RuntimeError())
 
         newf_exception = asyncio.Future(loop=self.loop)
-        _apply_future_state(f_exception, newf_exception)
+        _copy_future_state(f_exception, newf_exception)
         self.assertTrue(newf_exception.done())
         self.assertRaises(RuntimeError, newf_exception.result)
 
@@ -196,7 +196,7 @@ class FutureTests(test_utils.TestCase):
         f_cancelled.cancel()
 
         newf_cancelled = asyncio.Future(loop=self.loop)
-        _apply_future_state(f_cancelled, newf_cancelled)
+        _copy_future_state(f_cancelled, newf_cancelled)
         self.assertTrue(newf_cancelled.cancelled())
 
     def test_iter(self):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1244,7 +1244,7 @@ class TaskTests(test_utils.TestCase):
         task = asyncio.Task(gen, loop=self.loop)
         task.set_result('ok')
 
-        self.assertRaises(AssertionError, task._Task__step)
+        self.assertRaises(AssertionError, task._step)
         gen.close()
 
     def test_step_result(self):
@@ -1294,7 +1294,7 @@ class TaskTests(test_utils.TestCase):
             raise BaseException()
 
         task = asyncio.Task(notmutch(), loop=self.loop)
-        self.assertRaises(BaseException, task._Task__step)
+        self.assertRaises(BaseException, task._step)
 
         self.assertTrue(task.done())
         self.assertIsInstance(task.exception(), BaseException)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1244,7 +1244,7 @@ class TaskTests(test_utils.TestCase):
         task = asyncio.Task(gen, loop=self.loop)
         task.set_result('ok')
 
-        self.assertRaises(AssertionError, task._step)
+        self.assertRaises(AssertionError, task._Task__step)
         gen.close()
 
     def test_step_result(self):
@@ -1294,7 +1294,7 @@ class TaskTests(test_utils.TestCase):
             raise BaseException()
 
         task = asyncio.Task(notmutch(), loop=self.loop)
-        self.assertRaises(BaseException, task._step)
+        self.assertRaises(BaseException, task._Task__step)
 
         self.assertTrue(task.done())
         self.assertIsInstance(task.exception(), BaseException)


### PR DESCRIPTION
This PR cleans up Future class by factoring out `_copy_state()` and `_set_result_unless_cancelled()` into separate functions.