### PR TITLE
Error if awaiting in parallel on the same coroutine (in debug mode)

### DIFF
--- a/asyncio/coroutines.py
+++ b/asyncio/coroutines.py
@@ -140,7 +140,13 @@ class CoroWrapper:
 
     if compat.PY35:
 
-        __await__ = __iter__ # make compatible with 'await' expression
+        def __await__(self):
+            cr_await = getattr(self.gen, 'cr_await', None)
+            if cr_await is not None:
+                raise RuntimeError(
+                    "Cannot await on coroutine {!r} while it's "
+                    "awaiting for {!r}".format(self.gen, cr_await))
+            return self
 
         @property
         def gi_yieldfrom(self):

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -203,6 +203,26 @@ class CoroutineTests(BaseTest):
 
         self.loop.run_until_complete(runner())
 
+    def test_double_await(self):
+        async def afunc():
+            await asyncio.sleep(0.1, loop=self.loop)
+
+        async def runner():
+            coro = afunc()
+            t = asyncio.Task(coro, loop=self.loop)
+            try:
+                await asyncio.sleep(0, loop=self.loop)
+                await coro
+            finally:
+                t.cancel()
+
+        self.loop.set_debug(True)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r'Cannot await.*test_double_await.*\bafunc\b.*while.*\bsleep\b'):
+
+            self.loop.run_until_complete(runner())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This patch prevents coroutines to be awaited by more than one waiters simultaneously.  It affects only `async def` coroutines by patching `CoroWrapper.__await__`; I'm a bit hesitant to touch `CoroWrapper.__iter__`.

See issue #288 for details.