### PR TITLE
Make tests that use TestCase.subTest work in Python 3.3

### DIFF
--- a/asyncio/test_utils.py
+++ b/asyncio/test_utils.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: no cover
     ssl = None
 
 from . import base_events
+from . import compat
 from . import events
 from . import futures
 from . import selectors
@@ -420,6 +421,16 @@ class TestCase(unittest.TestCase):
         # Detect CPython bug #23353: ensure that yield/yield-from is not used
         # in an except block of a generator
         self.assertEqual(sys.exc_info(), (None, None, None))
+
+    if not compat.PY34:
+        # Python 3.3 compatibility
+        def subTest(self, *args, **kwargs):
+            class EmptyCM:
+                def __enter__(self):
+                    pass
+                def __exit__(self, *exc):
+                    pass
+            return EmptyCM()
 
 
 @contextlib.contextmanager

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -782,9 +782,10 @@ class BaseEventLoopTests(test_utils.TestCase):
         self.loop._selector.select.return_value = (event_sentinel,)
 
         for i in range(1, 3):
-            self.loop.call_soon(self.loop.stop)
-            self.loop.run_forever()
-            self.assertEqual(callcount, 1)
+            with self.subTest('Loop %d/2' % i):
+                self.loop.call_soon(self.loop.stop)
+                self.loop.run_forever()
+                self.assertEqual(callcount, 1)
 
     def test_run_once(self):
         # Simple test for test_utils.run_once().  It may seem strange


### PR DESCRIPTION
Couldn't push recent updates to CPython repo -- a push hook ensuring proper indentation failed. I think that using `subTest` is a great idea, we just need to make it not fail in 3.3.