### PR TITLE
Copy/paste Python3.5 test.support to test_support

### DIFF
--- a/asyncio/test_support.py
+++ b/asyncio/test_support.py
@@ -4,6 +4,7 @@
 
 # Ignore symbol TEST_HOME_DIR: test_events works without it
 
+import contextlib
 import functools
 import gc
 import os
@@ -13,6 +14,7 @@ import socket
 import subprocess
 import sys
 import time
+import warnings
 
 
 # A constant likely larger than the underlying OS pipe buffer size, to
@@ -291,6 +293,89 @@ def requires_freebsd_version(*min_version):
     version is less than 7.2.
     """
     return _requires_unix_version('FreeBSD', min_version)
+
+class WarningsRecorder(object):
+    """Convenience wrapper for the warnings list returned on
+       entry to the warnings.catch_warnings() context manager.
+    """
+    def __init__(self, warnings_list):
+        self._warnings = warnings_list
+        self._last = 0
+
+    def __getattr__(self, attr):
+        if len(self._warnings) > self._last:
+            return getattr(self._warnings[-1], attr)
+        elif attr in warnings.WarningMessage._WARNING_DETAILS:
+            return None
+        raise AttributeError("%r has no attribute %r" % (self, attr))
+
+    @property
+    def warnings(self):
+        return self._warnings[self._last:]
+
+    def reset(self):
+        self._last = len(self._warnings)
+
+def _filterwarnings(filters, quiet=False):
+    """Catch the warnings, then check if all the expected
+    warnings have been raised and re-raise unexpected warnings.
+    If 'quiet' is True, only re-raise the unexpected warnings.
+    """
+    # Clear the warning registry of the calling module
+    # in order to re-raise the warnings.
+    frame = sys._getframe(2)
+    registry = frame.f_globals.get('__warningregistry__')
+    if registry:
+        registry.clear()
+    with warnings.catch_warnings(record=True) as w:
+        # Set filter "always" to record all warnings.  Because
+        # test_warnings swap the module, we need to look up in
+        # the sys.modules dictionary.
+        sys.modules['warnings'].simplefilter("always")
+        yield WarningsRecorder(w)
+    # Filter the recorded warnings
+    reraise = list(w)
+    missing = []
+    for msg, cat in filters:
+        seen = False
+        for w in reraise[:]:
+            warning = w.message
+            # Filter out the matching messages
+            if (re.match(msg, str(warning), re.I) and
+                issubclass(warning.__class__, cat)):
+                seen = True
+                reraise.remove(w)
+        if not seen and not quiet:
+            # This filter caught nothing
+            missing.append((msg, cat.__name__))
+    if reraise:
+        raise AssertionError("unhandled warning %s" % reraise[0])
+    if missing:
+        raise AssertionError("filter (%r, %s) did not catch any warning" %
+                             missing[0])
+
+@contextlib.contextmanager
+def check_warnings(*filters, **kwargs):
+    """Context manager to silence warnings.
+
+    Accept 2-tuples as positional arguments:
+        ("message regexp", WarningCategory)
+
+    Optional argument:
+     - if 'quiet' is True, it does not fail if a filter catches nothing
+        (default True without argument,
+         default False if some filters are defined)
+
+    Without argument, it defaults to:
+        check_warnings(("", Warning), quiet=True)
+    """
+    quiet = kwargs.get('quiet')
+    if not filters:
+        filters = (("", Warning),)
+        # Preserve backward compatibility
+        if quiet is None:
+            quiet = True
+    return _filterwarnings(filters, quiet)
 
 # Use test.support if available
 try:

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -4,7 +4,10 @@ import collections.abc
 import types
 import unittest
 
-from test import support
+try:
+    from test import support
+except ImportError:
+    from asyncio import test_support as support
 from unittest import mock
 
 import asyncio


### PR DESCRIPTION
On test envs without test.support tests were unable to run.  At first because of the following import error and then due to missing components in the test_support module.

:; python3 ./setup.py test
running test
running egg_info
writing dependency_links to asyncio.egg-info/dependency_links.txt
writing asyncio.egg-info/PKG-INFO
writing top-level names to asyncio.egg-info/top_level.txt
reading manifest file 'asyncio.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'asyncio.egg-info/SOURCES.txt'
running build_ext
Traceback (most recent call last):
  File "./setup.py", line 48, in <module>
    ext_modules=extensions,
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.5/site-packages/setuptools/command/test.py", line 142, in run
    self.with_project_on_sys_path(self.run_tests)
  File "/usr/local/lib/python3.5/site-packages/setuptools/command/test.py", line 122, in with_project_on_sys_path
    func()
  File "/usr/local/lib/python3.5/site-packages/setuptools/command/test.py", line 163, in run_tests
    testRunner=self._resolve_as_ep(self.test_runner),
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/main.py", line 93, in __init__
    self.parseArgs(argv)
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/main.py", line 140, in parseArgs
    self.createTests()
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/main.py", line 147, in createTests
    self.module)
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/loader.py", line 219, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/loader.py", line 219, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/local/Cellar/python3/3.5.0/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/loader.py", line 204, in loadTestsFromName
    test = obj()
  File "/Users/mayfield/project/asyncio/runtests.py", line 277, in runtests
    finder = TestsFinder(args.testsdir, includes, excludes)
  File "/Users/mayfield/project/asyncio/runtests.py", line 139, in __init__
    self.find_available_tests()
  File "/Users/mayfield/project/asyncio/runtests.py", line 146, in find_available_tests
    mods = [mod for mod, _ in load_modules(self._testsdir)]
  File "/Users/mayfield/project/asyncio/runtests.py", line 116, in load_modules
    mods.append((loader.load_module(), sourcefile))
  File "<frozen importlib._bootstrap_external>", line 385, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 806, in load_module
  File "<frozen importlib._bootstrap_external>", line 665, in load_module
  File "<frozen importlib._bootstrap>", line 268, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 662, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "tests/test_pep492.py", line 7, in <module>
    from test import support
ImportError: cannot import name 'support'