### PR TITLE
Fix timeout docstring example

### DIFF
--- a/asyncio/tasks.py
+++ b/asyncio/tasks.py
@@ -743,8 +743,8 @@ def timeout(timeout, *, loop=None):
 
     For example:
 
-    >>> with asyncio.timeout(0.001):
-    >>>     yield from coro()
+        with asyncio.timeout(0.001):
+            yield from coro()
 
 
     timeout: timeout value in seconds


### PR DESCRIPTION
The `>>> ` prefix defines new expression, so the example actually had two of 
these: one `with` and one `yield`. This will cause two syntax errors if you run 
doctests: incomplete `with` block and bad indention for `yield`. 

To make it correct, for inner blocks need to use `...` prefix instead:

    >>> with asyncio.timeout(0.001):
    ...      yield from coro()

However, no else examples uses such notation, so  the example 
turned into more consistent state.