### PR TITLE
Add UDP-related methods on the event loop.

### DIFF
--- a/asyncio/events.py
+++ b/asyncio/events.py
@@ -457,7 +457,13 @@ class AbstractEventLoop:
     def sock_recv(self, sock, nbytes):
         raise NotImplementedError
 
+    def sock_recvfrom(self, sock, nbytes):
+        raise NotImplementedError
+
     def sock_sendall(self, sock, data):
+        raise NotImplementedError
+
+    def sock_sendto(self, sock, data, address):
         raise NotImplementedError
 
     def sock_connect(self, sock, address):


### PR DESCRIPTION
Adds `sock_recvfrom` and `sock_sendto` to the event loop. Tests were added, based on the other tests. There's no Proactor support yet, because it requires changing `overlapped.c`. 

I did some quick research and it seems that `sendto` might block, although it usually does not, hence why I also added it.