### PR TITLE
Prevent StopIteration from being thrown into a Future

### DIFF
--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -342,7 +342,7 @@ class Future:
         if isinstance(exception, type):
             exception = exception()
         if type(exception) is StopIteration:
-            raise TypeError("StopException interacts badly with generators "
+            raise TypeError("StopIteration interacts badly with generators "
                             "and cannot be raised into a Future")
         self._exception = exception
         self._state = _FINISHED

--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -342,7 +342,8 @@ class Future:
         if isinstance(exception, type):
             exception = exception()
         if type(exception) is StopIteration:
-            raise TypeError("StopException interacts badly with generators and cannot be raised into a Future")
+            raise TypeError("StopException interacts badly with generators "
+                    "and cannot be raised into a Future")
         self._exception = exception
         self._state = _FINISHED
         self._schedule_callbacks()

--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -343,7 +343,7 @@ class Future:
             exception = exception()
         if type(exception) is StopIteration:
             raise TypeError("StopException interacts badly with generators "
-                    "and cannot be raised into a Future")
+                            "and cannot be raised into a Future")
         self._exception = exception
         self._state = _FINISHED
         self._schedule_callbacks()

--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -341,7 +341,7 @@ class Future:
             raise InvalidStateError('{}: {!r}'.format(self._state, self))
         if isinstance(exception, type):
             exception = exception()
-        if isinstance(exception, StopIteration):
+        if type(exception) is StopIteration:
             raise TypeError("StopException interacts badly with generators and cannot be raised into a Future")
         self._exception = exception
         self._state = _FINISHED

--- a/asyncio/futures.py
+++ b/asyncio/futures.py
@@ -341,6 +341,8 @@ class Future:
             raise InvalidStateError('{}: {!r}'.format(self._state, self))
         if isinstance(exception, type):
             exception = exception()
+        if isinstance(exception, StopIteration):
+            raise TypeError("StopException interacts badly with generators and cannot be raised into a Future")
         self._exception = exception
         self._state = _FINISHED
         self._schedule_callbacks()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -76,6 +76,9 @@ class FutureTests(test_utils.TestCase):
         f = asyncio.Future(loop=self.loop)
         self.assertRaises(asyncio.InvalidStateError, f.exception)
 
+        # StopIteration cannot be raised into a Future - CPython issue26221
+        self.assertRaises(TypeError, f.set_exception, StopIteration)
+
         f.set_exception(exc)
         self.assertFalse(f.cancelled())
         self.assertTrue(f.done())

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -77,7 +77,8 @@ class FutureTests(test_utils.TestCase):
         self.assertRaises(asyncio.InvalidStateError, f.exception)
 
         # StopIteration cannot be raised into a Future - CPython issue26221
-        self.assertRaises(TypeError, f.set_exception, StopIteration)
+        self.assertRaisesRegex(TypeError, "StopIteration .* cannot be raised",
+                               f.set_exception, StopIteration)
 
         f.set_exception(exc)
         self.assertFalse(f.cancelled())


### PR DESCRIPTION
Raising StopIteration inside a Future will either result in a spurious
return-like action, or a RuntimeError, depending on the Python version.