### PR TITLE
Add EPOLLEXCLUSIVE support to EpollSelector

### DIFF
--- a/asyncio/selectors.py
+++ b/asyncio/selectors.py
@@ -16,6 +16,9 @@ import sys
 EVENT_READ = (1 << 0)
 EVENT_WRITE = (1 << 1)
 
+# flag used by bitwise OR.  It may be ignored in unsupported platforms.
+EVENT_EXCLUSIVE = (1 << 2)
+
 
 def _fileobj_to_fd(fileobj):
     """Return a file descriptor from a file object.
@@ -391,6 +394,8 @@ if hasattr(select, 'poll'):
 
 if hasattr(select, 'epoll'):
 
+    _EPOLLEXCLUSIVE = (1 << 28)  # old Linux (~4.4) ignores this flag.
+
     class EpollSelector(_BaseSelectorImpl):
         """Epoll-based selector."""
 
@@ -408,6 +413,8 @@ if hasattr(select, 'epoll'):
                 epoll_events |= select.EPOLLIN
             if events & EVENT_WRITE:
                 epoll_events |= select.EPOLLOUT
+            if events & EVENT_EXCLUSIVE:
+                epoll_events |= _EPOLLEXCLUSIVE
             self._epoll.register(key.fd, epoll_events)
             return key
 

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -64,6 +64,30 @@ class BaseSelectorTestCase(unittest.TestCase):
         self.assertRaises(KeyError, s.register, rd.fileno(),
                           selectors.EVENT_READ)
 
+    def test_register_exclusive(self):
+        s = self.SELECTOR()
+        self.addCleanup(s.close)
+
+        rd, wr = self.make_socketpair()
+
+        key = s.register(rd, selectors.EVENT_READ | selectors.EVENT_EXCLUSIVE,
+                         "data")
+        self.assertIsInstance(key, selectors.SelectorKey)
+        self.assertEqual(key.fileobj, rd)
+        self.assertEqual(key.fd, rd.fileno())
+        self.assertEqual(key.events,
+                         selectors.EVENT_READ | selectors.EVENT_EXCLUSIVE)
+        self.assertEqual(key.data, "data")
+
+        key = s.register(wr, selectors.EVENT_WRITE | selectors.EVENT_EXCLUSIVE,
+                         "data2")
+        self.assertIsInstance(key, selectors.SelectorKey)
+        self.assertEqual(key.fileobj, wr)
+        self.assertEqual(key.fd, wr.fileno())
+        self.assertEqual(key.events,
+                         selectors.EVENT_WRITE | selectors.EVENT_EXCLUSIVE)
+        self.assertEqual(key.data, "data2")
+
     def test_unregister(self):
         s = self.SELECTOR()
         self.addCleanup(s.close)


### PR DESCRIPTION
EPOLLEXCLUSIVE was introduced in Linux 4.5.
It can be used to avoid thundering herd problem.

Reference:
http://man7.org/linux/man-pages/man2/epoll_ctl.2.html
https://lwn.net/Articles/633422/