### PR TITLE
make asyncio's communicate() handle empty input

### DIFF
--- a/asyncio/subprocess.py
+++ b/asyncio/subprocess.py
@@ -166,7 +166,7 @@ class Process:
 
     @coroutine
     def communicate(self, input=None):
-        if input:
+        if input is not None:
             stdin = self._feed_stdin(input)
         else:
             stdin = self._noop()

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -287,6 +287,25 @@ class SubprocessMixin:
         self.assertEqual(output.rstrip(), b'3')
         self.assertEqual(exitcode, 0)
 
+    def test_empty_input(self):
+        @asyncio.coroutine
+        def empty_input():
+            code = 'import sys; data = sys.stdin.read(); print(len(data))'
+            proc = yield from asyncio.create_subprocess_exec(
+                                          sys.executable, '-c', code,
+                                          stdin=asyncio.subprocess.PIPE,
+                                          stdout=asyncio.subprocess.PIPE,
+                                          stderr=asyncio.subprocess.PIPE,
+                                          close_fds=False,
+                                          loop=self.loop)
+            stdout, stderr = yield from proc.communicate(b'')
+            exitcode = yield from proc.wait()
+            return (stdout, exitcode)
+
+        output, exitcode = self.loop.run_until_complete(empty_input())
+        self.assertEqual(output.rstrip(), b'0')
+        self.assertEqual(exitcode, 0)
+
     def test_cancel_process_wait(self):
         # Issue #23140: cancel Process.wait()
 


### PR DESCRIPTION
Previously communicate(b"") was the same as communicate(), which caused
subprocesses waiting for input to hang. Without this fix, the new test hangs forever.

I originally submitted this this as https://github.com/python/cpython/pull/33.