### PR TITLE
Add 'loop.get_exception_handler()' method.

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -1078,6 +1078,11 @@ class BaseEventLoop(events.AbstractEventLoop):
             logger.info('%s: %r' % (debug_log, transport))
         return transport, protocol
 
+    def get_exception_handler(self):
+        """Return an exception handler, or None if the default one is in use.
+        """
+        return self._exception_handler
+
     def set_exception_handler(self, handler):
         """Set handler as the new event loop exception handler.
 

--- a/asyncio/events.py
+++ b/asyncio/events.py
@@ -484,6 +484,9 @@ class AbstractEventLoop:
 
     # Error handlers.
 
+    def get_exception_handler(self):
+        raise NotImplementedError
+
     def set_exception_handler(self, handler):
         raise NotImplementedError
 

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -658,8 +658,10 @@ class BaseEventLoopTests(test_utils.TestCase):
         self.loop.set_debug(True)
         self.loop._process_events = mock.Mock()
 
+        self.assertIsNone(self.loop.get_exception_handler())
         mock_handler = mock.Mock()
         self.loop.set_exception_handler(mock_handler)
+        self.assertIs(self.loop.get_exception_handler(), mock_handler)
         handle = run_loop()
         mock_handler.assert_called_with(self.loop, {
             'exception': MOCK_ANY,


### PR DESCRIPTION
This PR implements a new event loop method `get_exception_handler()`. All other `set_*` methods have a corresponding `get_*` method. See also issue #340.