### PR TITLE
locks: Fix inconsistency cancelling Condition.wait.

### DIFF
--- a/asyncio/locks.py
+++ b/asyncio/locks.py
@@ -329,7 +329,13 @@ class Condition(_ContextManagerMixin):
                 self._waiters.remove(fut)
 
         finally:
-            yield from self.acquire()
+            # Must reacquire lock even if wait is cancelled
+            while True:
+                try:
+                    yield from self.acquire()
+                    break
+                except futures.CancelledError:
+                    pass
 
     @coroutine
     def wait_for(self, predicate):


### PR DESCRIPTION
Issue #22970: Cancelling wait() after notification leaves Condition in an
inconsistent state.

This can occur if the waiting task has been notified but has not reacquired the
associated lock. Instead of cancelling waiting for the notification, the cancel
call will cancel the lock reacquisition, returning control to the calling task
without the lock being held (a violation of Condition.wait contract).