### PR TITLE
loop.getaddrinfo accepts more types for "port" param.

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -102,6 +102,11 @@ def _ipaddr_info(host, port, family, type, proto):
     else:
         return None
 
+    if port in {None, ''}:
+        port = 0
+    elif isinstance(port, (bytes, str)):
+        port = int(port)
+
     if hasattr(socket, 'inet_pton'):
         if family == socket.AF_UNSPEC:
             afs = [socket.AF_INET, socket.AF_INET6]

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -120,6 +120,24 @@ class BaseEventTests(test_utils.TestCase):
             (INET6, STREAM, TCP, '', ('::3%lo0', 1)),
             base_events._ipaddr_info('::3%lo0', 1, INET6, STREAM, TCP))
 
+    def test_port_parameter_types(self):
+        # Test obscure kinds of arguments for "port".
+        INET = socket.AF_INET
+        STREAM = socket.SOCK_STREAM
+        TCP = socket.IPPROTO_TCP
+
+        self.assertEqual(
+            (INET, STREAM, TCP, '', ('1.2.3.4', 0)),
+            base_events._ipaddr_info('1.2.3.4', None, INET, STREAM, TCP))
+
+        self.assertEqual(
+            (INET, STREAM, TCP, '', ('1.2.3.4', 0)),
+            base_events._ipaddr_info('1.2.3.4', '', INET, STREAM, TCP))
+
+        self.assertEqual(
+            (INET, STREAM, TCP, '', ('1.2.3.4', 1)),
+            base_events._ipaddr_info('1.2.3.4', '1', INET, STREAM, TCP))
+
     @patch_socket
     def test_ipaddr_info_no_inet_pton(self, m_socket):
         del m_socket.inet_pton

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -138,6 +138,10 @@ class BaseEventTests(test_utils.TestCase):
             (INET, STREAM, TCP, '', ('1.2.3.4', 1)),
             base_events._ipaddr_info('1.2.3.4', '1', INET, STREAM, TCP))
 
+        self.assertEqual(
+            (INET, STREAM, TCP, '', ('1.2.3.4', 1)),
+            base_events._ipaddr_info('1.2.3.4', b'1', INET, STREAM, TCP))
+
     @patch_socket
     def test_ipaddr_info_no_inet_pton(self, m_socket):
         del m_socket.inet_pton


### PR DESCRIPTION
loop.getaddrinfo accepts more types for "port" param.

Ensure asyncio's getaddrinfo handles port=None, str, bytes, and empty
str the same as typical platforms' socket.getaddrinfo does.