### PR TITLE
Ensure get_event_loop returns the running loop when called in a coroutine

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -342,11 +342,15 @@ class BaseEventLoop(events.AbstractEventLoop):
         self._set_coroutine_wrapper(self._debug)
         self._thread_id = threading.get_ident()
         try:
-            with self._running_context():
+            policy = events.get_event_loop_policy()
+            policy.set_running_loop(self)
+            try:
                 while True:
                     self._run_once()
                     if self._stopping:
                         break
+            finally:
+                policy.set_running_loop(None)
         finally:
             self._stopping = False
             self._thread_id = None

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -342,10 +342,11 @@ class BaseEventLoop(events.AbstractEventLoop):
         self._set_coroutine_wrapper(self._debug)
         self._thread_id = threading.get_ident()
         try:
-            while True:
-                self._run_once()
-                if self._stopping:
-                    break
+            with self._running_context():
+                while True:
+                    self._run_once()
+                    if self._stopping:
+                        break
         finally:
             self._stopping = False
             self._thread_id = None

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -339,22 +339,20 @@ class BaseEventLoop(events.AbstractEventLoop):
         self._check_closed()
         if self.is_running():
             raise RuntimeError('Event loop is running.')
+        policy = events.get_event_loop_policy()
+        policy.set_running_loop(self)
         self._set_coroutine_wrapper(self._debug)
         self._thread_id = threading.get_ident()
         try:
-            policy = events.get_event_loop_policy()
-            policy.set_running_loop(self)
-            try:
-                while True:
-                    self._run_once()
-                    if self._stopping:
-                        break
-            finally:
-                policy.set_running_loop(None)
+            while True:
+                self._run_once()
+                if self._stopping:
+                    break
         finally:
             self._stopping = False
             self._thread_id = None
             self._set_coroutine_wrapper(False)
+            policy.set_running_loop(None)
 
     def run_until_complete(self, future):
         """Run until the Future is done.

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -340,10 +340,10 @@ class BaseEventLoop(events.AbstractEventLoop):
         if self.is_running():
             raise RuntimeError('Event loop is running.')
         policy = events.get_event_loop_policy()
-        policy.set_running_loop(self)
         self._set_coroutine_wrapper(self._debug)
         self._thread_id = threading.get_ident()
         try:
+            policy.set_running_loop(self)
             while True:
                 self._run_once()
                 if self._stopping:
@@ -351,8 +351,8 @@ class BaseEventLoop(events.AbstractEventLoop):
         finally:
             self._stopping = False
             self._thread_id = None
-            self._set_coroutine_wrapper(False)
             policy.set_running_loop(None)
+            self._set_coroutine_wrapper(False)
 
     def run_until_complete(self, future):
         """Run until the Future is done.

--- a/asyncio/events.py
+++ b/asyncio/events.py
@@ -547,9 +547,11 @@ class AbstractEventLoopPolicy:
         raise NotImplementedError
 
     def new_event_loop(self):
-        """Create and return a new event loop object according to this
-        policy's rules. If there's need to set this loop as the event loop for
-        the current context, set_event_loop must be called explicitly.
+        """Create and return a new event loop object.
+
+        The loop is created according to the policy's rules.
+        If there is need to set this loop as the event loop for the
+        current context, set_event_loop must be called explicitly.
         """
         raise NotImplementedError
 

--- a/asyncio/events.py
+++ b/asyncio/events.py
@@ -607,7 +607,7 @@ class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
         return self._local._loop
 
     def set_event_loop(self, loop):
-        """Set the default event loop for the current thread."""
+        """Set the event loop for the current thread."""
         self._local._set_called = True
         assert loop is None or isinstance(loop, AbstractEventLoop)
         self._local._loop = loop

--- a/asyncio/events.py
+++ b/asyncio/events.py
@@ -523,7 +523,7 @@ class AbstractEventLoopPolicy:
         raise NotImplementedError
 
     def set_default_loop(self, loop):
-        """Set the default event loop for the current context to loop."""
+        """Set the default event loop for the current context."""
         raise NotImplementedError
 
     def get_running_loop(self):
@@ -563,20 +563,14 @@ class AbstractEventLoopPolicy:
     # Non-abstract methods
 
     def get_event_loop(self):
-        """Return the running event loop if any, and the default event
-        loop otherwise.
-        """
+        """Return the running loop if any, and the default loop otherwise."""
         running_loop = self.get_running_loop()
         if running_loop is not None:
             return running_loop
         return self.get_default_loop()
 
     def set_event_loop(self, loop):
-        """Set the default event loop if the former loop is not currently
-        running.
-        """
-        if self.get_running_loop() is not None:
-            raise RuntimeError('The former loop is currently running')
+        """Set the default event loop for the current context."""
         self.set_default_loop(loop)
 
 

--- a/asyncio/events.py
+++ b/asyncio/events.py
@@ -518,10 +518,9 @@ class AbstractEventLoopPolicy:
         - the running loop if it has been set (using set_running_loop)
         - the loop for the current context otherwise.
 
-        It may also raise an exception in case no event loop has been set for the
-        current context and the current policy does not specify to create one.
-
-        It should never return None.
+        It may also raise an exception in case no event loop has been set for
+        the current context and the current policy does not specify to create
+        one. It should never return None.
         """
         raise NotImplementedError
 

--- a/asyncio/events.py
+++ b/asyncio/events.py
@@ -624,7 +624,6 @@ class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
     def set_running_loop(self, loop):
         """Set the running event loop for the current thread."""
         assert loop is None or isinstance(loop, AbstractEventLoop)
-        default_loop = self._local._loop
         running_loop = self._local._running_loop
         if running_loop is not None and loop is not None:
             raise RuntimeError('A loop is already running')

--- a/asyncio/test_utils.py
+++ b/asyncio/test_utils.py
@@ -407,6 +407,8 @@ class TestCase(unittest.TestCase):
         assert loop is not None
         # ensure that the event loop is passed explicitly in asyncio
         events.set_event_loop(None)
+        # Disable event loop policy warnings
+        events.get_event_loop_policy()._warnings = False
         if cleanup:
             self.addCleanup(loop.close)
 
@@ -417,6 +419,8 @@ class TestCase(unittest.TestCase):
 
     def tearDown(self):
         events.set_event_loop(None)
+        # Enable event loop policy warnings
+        events.get_event_loop_policy()._warnings = True
 
         # Detect CPython bug #23353: ensure that yield/yield-from is not used
         # in an except block of a generator

--- a/asyncio/test_utils.py
+++ b/asyncio/test_utils.py
@@ -407,8 +407,6 @@ class TestCase(unittest.TestCase):
         assert loop is not None
         # ensure that the event loop is passed explicitly in asyncio
         events.set_event_loop(None)
-        # Disable event loop policy warnings
-        events.get_event_loop_policy()._warnings = False
         if cleanup:
             self.addCleanup(loop.close)
 
@@ -419,8 +417,6 @@ class TestCase(unittest.TestCase):
 
     def tearDown(self):
         events.set_event_loop(None)
-        # Enable event loop policy warnings
-        events.get_event_loop_policy()._warnings = True
 
         # Detect CPython bug #23353: ensure that yield/yield-from is not used
         # in an except block of a generator

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2467,6 +2467,9 @@ class PolicyTests(unittest.TestCase):
         self.assertRaises(NotImplementedError, policy.get_event_loop)
         self.assertRaises(NotImplementedError, policy.set_event_loop, object())
         self.assertRaises(NotImplementedError, policy.new_event_loop)
+        self.assertRaises(NotImplementedError, policy.get_running_loop)
+        self.assertRaises(NotImplementedError, policy.set_running_loop,
+                          object())
         self.assertRaises(NotImplementedError, policy.get_child_watcher)
         self.assertRaises(NotImplementedError, policy.set_child_watcher,
                           object())
@@ -2533,6 +2536,27 @@ class PolicyTests(unittest.TestCase):
         self.assertIsNot(old_loop, policy.get_event_loop())
         loop.close()
         old_loop.close()
+
+    def test_set_running_loop(self):
+        policy = asyncio.DefaultEventLoopPolicy()
+        self.assertIsNone(policy._local._running_loop)
+        self.assertIsNone(policy.get_running_loop())
+
+        self.assertRaises(AssertionError, policy.set_running_loop, object())
+
+        loop = policy.new_event_loop()
+        policy.set_running_loop(loop)
+
+        self.assertIs(policy._local._running_loop, loop)
+        self.assertIs(policy.get_running_loop(), loop)
+        loop.close()
+
+        loop2 = policy.new_event_loop()
+        self.assertRaises(RuntimeError, policy.set_running_loop, loop2)
+        loop2.close()
+
+        policy.set_running_loop(None)
+        self.assertIsNone(policy._local._running_loop)
 
     def test_get_event_loop_policy(self):
         policy = asyncio.get_event_loop_policy()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2558,6 +2558,33 @@ class PolicyTests(unittest.TestCase):
         policy.set_running_loop(None)
         self.assertIsNone(policy._local._running_loop)
 
+    def test_get_event_loop_after_set_running_loop(self):
+        policy = asyncio.DefaultEventLoopPolicy()
+
+        running_loop = policy.new_event_loop()
+        policy.set_running_loop(running_loop)
+
+        self.assertIsNone(policy._local._loop)
+        self.assertIs(policy.get_event_loop(), running_loop)
+
+        loop = policy.new_event_loop()
+        policy.set_event_loop(loop)
+
+        self.assertIs(policy._local._loop, loop)
+        self.assertIs(policy.get_event_loop(), running_loop)
+
+        policy.set_running_loop(None)
+        running_loop.close()
+
+        self.assertIs(policy._local._loop, loop)
+        self.assertIs(policy.get_event_loop(), loop)
+
+        policy.set_event_loop(None)
+        loop.close()
+
+        self.assertIsNone(policy._local._loop)
+        self.assertRaises(RuntimeError, policy.get_event_loop)
+
     def test_get_event_loop_policy(self):
         policy = asyncio.get_event_loop_policy()
         self.assertIsInstance(policy, asyncio.AbstractEventLoopPolicy)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2235,11 +2235,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
 class SleepTests(test_utils.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
-
-    def tearDown(self):
-        self.loop.close()
-        self.loop = None
+        self.set_event_loop(self.loop)
 
     def test_sleep_zero(self):
         result = 0
@@ -2263,11 +2259,7 @@ class SleepTests(test_utils.TestCase):
 class TimeoutTests(test_utils.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
-
-    def tearDown(self):
-        self.loop.close()
-        self.loop = None
+        self.set_event_loop(self.loop)
 
     def test_timeout(self):
         canceled_raised = [False]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2235,7 +2235,11 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
 class SleepTests(test_utils.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
-        self.set_event_loop(self.loop)
+        asyncio.set_event_loop(None)
+
+    def tearDown(self):
+        self.loop.close()
+        self.loop = None
 
     def test_sleep_zero(self):
         result = 0
@@ -2259,7 +2263,11 @@ class SleepTests(test_utils.TestCase):
 class TimeoutTests(test_utils.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
-        self.set_event_loop(self.loop)
+        asyncio.set_event_loop(None)
+
+    def tearDown(self):
+        self.loop.close()
+        self.loop = None
 
     def test_timeout(self):
         canceled_raised = [False]


### PR DESCRIPTION
This PR follows up on the [issue 26969](http://bugs.python.org/issue26969).

It is meant to ensure that `asyncio.get_event_loop` returns the running loop when called in a coroutine (or loop callbacks). This could simplify all the coroutines that includes a `loop` optional argument by removing it.

This is done by modifying  the interface of `AbstractEventLoopPolicy`:
- `get/set_event_loop` is renamed to `get/set_default_loop`
- `get/set_running_loop` is added
- `get_event_loop` now uses the running loop if available, and the default loop otherwise

`BaseEventLoopPolicy` is updated, and adds a few features:
- it does not allow to set a running loop if another one is already set
- it issues warnings if the running loop doesn't correspond to the default loop

A context manager is also added to `AbstractEventLoopPolicy` and `AbstractEventLoop` to set and clear the running loop in a safe manner. This might help for other event loop implementations.
