### PR TITLE
WIP: Begin to allow getaddrinfo as a fallback in connect_socket.

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -806,9 +806,9 @@ class BaseEventLoop(events.AbstractEventLoop):
                         assert isinstance(addr, tuple) and len(addr) == 2, (
                             '2-tuple is expected')
 
-                        infos = yield from self.getaddrinfo(
+                        infos = yield from _ensure_resolved(
                             *addr, family=family, type=socket.SOCK_DGRAM,
-                            proto=proto, flags=flags)
+                            proto=proto, flags=flags, loop=self)
                         if not infos:
                             raise OSError('getaddrinfo() returned empty list')
 

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -129,13 +129,13 @@ def _ipaddr_info(host, port, family, type, proto):
 
     for af in afs:
         # Linux's inet_pton doesn't accept an IPv6 zone index after host,
-        # like '::1%lo0', so strip it. If we happen to make an invalid
-        # address look valid, we fail later in sock.connect or sock.bind.
+        # like '::1%lo0'.
+        if '%' in host:
+            return None
+
         try:
-            if af == socket.AF_INET6:
-                socket.inet_pton(af, host.partition('%')[0])
-            else:
-                socket.inet_pton(af, host)
+            socket.inet_pton(af, host)
+            # The host has already been resolved.
             return af, type, proto, '', (host, port)
         except OSError:
             pass

--- a/asyncio/proactor_events.py
+++ b/asyncio/proactor_events.py
@@ -440,14 +440,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         return self._proactor.send(sock, data)
 
     def sock_connect(self, sock, address):
-        try:
-            base_events._check_resolved_address(sock, address)
-        except ValueError as err:
-            fut = self.create_future()
-            fut.set_exception(err)
-            return fut
-        else:
-            return self._proactor.connect(sock, address)
+        return self._proactor.connect(sock, address)
 
     def sock_accept(self, sock):
         return self._proactor.accept(sock)

--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -404,7 +404,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
     def _sock_connect(self, fut, sock, resolved):
         try:
-            address = resolved.result()[0]
+            _, _, _, _, address = resolved.result()[0]
         except Exception as exc:
             fut.set_exception(exc)
             sock.close()

--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -396,7 +396,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         fut = self.create_future()
-        resolved = self._ensure_resolved(*address)
+        resolved = base_events._ensure_resolved(*address, loop=self)
         resolved.add_done_callback(
             lambda resolved: self._sock_connect(fut, sock, resolved))
 

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -109,8 +109,7 @@ class BaseEventTests(test_utils.TestCase):
             base_events._ipaddr_info('::3', 1, INET, STREAM, TCP))
 
         # IPv6 address with zone index.
-        self.assertEqual(
-            (INET6, STREAM, TCP, '', ('::3%lo0', 1)),
+        self.assertIsNone(
             base_events._ipaddr_info('::3%lo0', 1, INET6, STREAM, TCP))
 
     def test_port_parameter_types(self):

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -171,30 +171,6 @@ class BaseEventTests(test_utils.TestCase):
         del m_socket.inet_pton
         self.test_ipaddr_info()
 
-    def test_check_resolved_address(self):
-        sock = socket.socket(socket.AF_INET)
-        with sock:
-            base_events._check_resolved_address(sock, ('1.2.3.4', 1))
-
-        sock = socket.socket(socket.AF_INET6)
-        with sock:
-            base_events._check_resolved_address(sock, ('::3', 1))
-            base_events._check_resolved_address(sock, ('::3%lo0', 1))
-            with self.assertRaises(ValueError):
-                base_events._check_resolved_address(sock, ('foo', 1))
-
-    def test_check_resolved_sock_type(self):
-        # Ensure we ignore extra flags in sock.type.
-        if hasattr(socket, 'SOCK_NONBLOCK'):
-            sock = socket.socket(type=socket.SOCK_STREAM | socket.SOCK_NONBLOCK)
-            with sock:
-                base_events._check_resolved_address(sock, ('1.2.3.4', 1))
-
-        if hasattr(socket, 'SOCK_CLOEXEC'):
-            sock = socket.socket(type=socket.SOCK_STREAM | socket.SOCK_CLOEXEC)
-            with sock:
-                base_events._check_resolved_address(sock, ('1.2.3.4', 1))
-
 
 class BaseEventLoopTests(test_utils.TestCase):
 

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -1173,9 +1173,9 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         t, p = self.loop.run_until_complete(coro)
         try:
             sock.connect.assert_called_with(('1.2.3.4', 80))
-            m_socket.socket.assert_called_with(family=m_socket.AF_INET,
-                                               proto=m_socket.IPPROTO_TCP,
-                                               type=m_socket.SOCK_STREAM)
+            _, kwargs = m_socket.socket.call_args
+            self.assertEqual(kwargs['family'], m_socket.AF_INET)
+            self.assertEqual(kwargs['type'], m_socket.SOCK_STREAM)
         finally:
             t.close()
             test_utils.run_briefly(self.loop)  # allow transport to close
@@ -1190,9 +1190,9 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             host, port = address[:2]
             self.assertRegex(host, r'::(0\.)*2')
             self.assertEqual(port, 80)
-            m_socket.socket.assert_called_with(family=m_socket.AF_INET6,
-                                               proto=m_socket.IPPROTO_TCP,
-                                               type=m_socket.SOCK_STREAM)
+            _, kwargs = m_socket.socket.call_args
+            self.assertEqual(kwargs['family'], m_socket.AF_INET6)
+            self.assertEqual(kwargs['type'], m_socket.SOCK_STREAM)
         finally:
             t.close()
             test_utils.run_briefly(self.loop)  # allow transport to close

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -1189,7 +1189,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             # to ('::0.0.0.2', 80, 0, 0). The last 0s are flow info, scope id.
             [address] = sock.connect.call_args[0]
             host, port = address[:2]
-            self.assertRegexpMatches(host, r'::(0\.)*2')
+            self.assertRegex(host, r'::(0\.)*2')
             self.assertEqual(port, 80)
             m_socket.socket.assert_called_with(family=m_socket.AF_INET6,
                                                proto=m_socket.IPPROTO_TCP,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1610,25 +1610,6 @@ class EventLoopTestsMixin:
             {'clock_resolution': self.loop._clock_resolution,
              'selector': self.loop._selector.__class__.__name__})
 
-    def test_sock_connect_address(self):
-        addresses = [(socket.AF_INET, ('www.python.org', 80))]
-        if support.IPV6_ENABLED:
-            addresses.extend((
-                (socket.AF_INET6, ('www.python.org', 80)),
-                (socket.AF_INET6, ('www.python.org', 80, 0, 0)),
-            ))
-
-        for family, address in addresses:
-            for sock_type in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
-                sock = socket.socket(family, sock_type)
-                with sock:
-                    sock.setblocking(False)
-                    connect = self.loop.sock_connect(sock, address)
-                    with self.assertRaises(ValueError) as cm:
-                        self.loop.run_until_complete(connect)
-                    self.assertIn('address must be resolved',
-                                  str(cm.exception))
-
     def test_remove_fds_after_closing(self):
         loop = self.create_event_loop()
         callback = lambda: None

--- a/tests/test_selector_events.py
+++ b/tests/test_selector_events.py
@@ -344,13 +344,10 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         f = self.loop.sock_connect(sock, ('127.0.0.1', 8080))
         self.assertIsInstance(f, asyncio.Future)
         self.loop._run_once()
-        future_in, sock_in, resolved_in = self.loop._sock_connect.call_args[0]
+        future_in, sock_in, address_in = self.loop._sock_connect.call_args[0]
         self.assertEqual(future_in, f)
         self.assertEqual(sock_in, sock)
-        self.assertEqual(
-            resolved_in.result(),
-            [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, '',
-              ('127.0.0.1', 8080))])
+        self.assertEqual(address_in, ('127.0.0.1', 8080))
 
     def test_sock_connect_timeout(self):
         # asyncio issue #205: sock_connect() must unregister the socket on

--- a/tests/test_selector_events.py
+++ b/tests/test_selector_events.py
@@ -343,9 +343,14 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
 
         f = self.loop.sock_connect(sock, ('127.0.0.1', 8080))
         self.assertIsInstance(f, asyncio.Future)
+        self.loop._run_once()
+        future_in, sock_in, resolved_in = self.loop._sock_connect.call_args[0]
+        self.assertEqual(future_in, f)
+        self.assertEqual(sock_in, sock)
         self.assertEqual(
-            (f, sock, ('127.0.0.1', 8080)),
-            self.loop._sock_connect.call_args[0])
+            resolved_in.result(),
+            [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, '',
+              ('127.0.0.1', 8080))])
 
     def test_sock_connect_timeout(self):
         # asyncio issue #205: sock_connect() must unregister the socket on
@@ -359,6 +364,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
 
         # first call to sock_connect() registers the socket
         fut = self.loop.sock_connect(sock, ('127.0.0.1', 80))
+        self.loop._run_once()
         self.assertTrue(sock.connect.called)
         self.assertTrue(self.loop.add_writer.called)
         self.assertEqual(len(fut._callbacks), 1)
@@ -376,7 +382,10 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock = mock.Mock()
         sock.fileno.return_value = 10
 
-        self.loop._sock_connect(f, sock, ('127.0.0.1', 8080))
+        resolved = self.loop.create_future()
+        resolved.set_result([(socket.AF_INET, socket.SOCK_STREAM,
+                              socket.IPPROTO_TCP, '', ('127.0.0.1', 8080))])
+        self.loop._sock_connect(f, sock, resolved)
         self.assertTrue(f.done())
         self.assertIsNone(f.result())
         self.assertTrue(sock.connect.called)
@@ -402,9 +411,13 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock.connect.side_effect = BlockingIOError
         sock.getsockopt.return_value = 0
         address = ('127.0.0.1', 8080)
+        resolved = self.loop.create_future()
+        resolved.set_result([(socket.AF_INET, socket.SOCK_STREAM,
+                              socket.IPPROTO_TCP, '', address)])
 
         f = asyncio.Future(loop=self.loop)
-        self.loop._sock_connect(f, sock, address)
+        self.loop._sock_connect(f, sock, resolved)
+        self.loop._run_once()
         self.assertTrue(self.loop.add_writer.called)
         self.assertEqual(10, self.loop.add_writer.call_args[0][0])
 


### PR DESCRIPTION
This is an approach to http://bugs.python.org/issue27136. It allows getaddrinfo for addresses we can't parse, like the Bluetooth address in that bug report. My theory is that, since getaddrinfo no longer has a mutex on popular platforms, it's ok to call it to confirm that an address has been resolved already, in cases where we can't confirm it in asyncio.

The `BaseSelectorEventLoopTests` pass with Python 3.4 and 3.5 on Mac, Linux, and Windows; other tests would need to be updated before this can be merged.

Based on @1st1's suggestions: credit is due to him, but blame mistakes on me.