### PR TITLE
Use socket specs for getaddrinfo() in sock_connect()

### DIFF
--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -394,7 +394,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         if hasattr(socket, 'AF_UNIX') and sock.family == socket.AF_UNIX:
             self._sock_connect(fut, sock, address)
         else:
-            resolved = base_events._ensure_resolved(address, loop=self)
+            resolved = base_events._ensure_resolved(
+                address, family=sock.family, proto=sock.proto, loop=self)
             resolved.add_done_callback(
                 lambda resolved: self._on_resolved(fut, sock, resolved))
 

--- a/tests/test_selector_events.py
+++ b/tests/test_selector_events.py
@@ -373,6 +373,17 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
             self.loop.run_until_complete(fut)
         self.assertTrue(self.loop.remove_writer.called)
 
+    def test_sock_connect_resolve_using_socket_params(self):
+        addr = ('need-resolution.com', 8080)
+        sock = test_utils.mock_nonblocking_socket()
+        self.loop.getaddrinfo = mock.Mock()
+        self.loop.sock_connect(sock, addr)
+        while not self.loop.getaddrinfo.called:
+            self.loop._run_once()
+        self.loop.getaddrinfo.assert_called_with(
+            *addr, type=sock.type, family=sock.family, proto=sock.proto,
+            flags=0)
+
     def test__sock_connect(self):
         f = asyncio.Future(loop=self.loop)
 


### PR DESCRIPTION
In ``BaseSelectorEventLoop.sock_connect()``, an address is resolved if needed, but
``getaddrinfo()`` isn't called with the socket's parameters (family, proto, etc).
If the resolved address mismatch the socket type, the connection fails.

For instance, if ``getaddrinfo()`` returns an IPv6 (``AF_INET6``) resolution and the
socket is of family ``AF_INET``, ``sock_connect()`` eventually raises a ``TypeError``.

This PR is a follow-up to #357.