### PR TITLE
Fix ordering issues in UNIX read/write pipe transport constructors

### DIFF
--- a/asyncio/locks.py
+++ b/asyncio/locks.py
@@ -166,7 +166,7 @@ class Lock(_ContextManagerMixin):
         This method blocks until the lock is unlocked, then sets it to
         locked and returns True.
         """
-        if not self._waiters and not self._locked:
+        if not self._locked and all(w.cancelled() for w in self._waiters):
             self._locked = True
             return True
 

--- a/asyncio/unix_events.py
+++ b/asyncio/unix_events.py
@@ -305,14 +305,20 @@ class _UnixReadPipeTransport(transports.ReadTransport):
         self._loop = loop
         self._pipe = pipe
         self._fileno = pipe.fileno()
+        self._protocol = protocol
+        self._closing = False
+
         mode = os.fstat(self._fileno).st_mode
         if not (stat.S_ISFIFO(mode) or
                 stat.S_ISSOCK(mode) or
                 stat.S_ISCHR(mode)):
+            self._pipe = None
+            self._fileno = None
+            self._protocol = None
             raise ValueError("Pipe transport is for pipes/sockets only.")
+
         _set_nonblocking(self._fileno)
-        self._protocol = protocol
-        self._closing = False
+
         self._loop.call_soon(self._protocol.connection_made, self)
         # only start reading when connection_made() has been called
         self._loop.call_soon(self._loop.add_reader,
@@ -421,18 +427,23 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         self._extra['pipe'] = pipe
         self._pipe = pipe
         self._fileno = pipe.fileno()
+        self._protocol = protocol
+        self._buffer = []
+        self._conn_lost = 0
+        self._closing = False  # Set when close() or write_eof() called.
+
         mode = os.fstat(self._fileno).st_mode
         is_socket = stat.S_ISSOCK(mode)
         if not (is_socket or
                 stat.S_ISFIFO(mode) or
                 stat.S_ISCHR(mode)):
+            self._pipe = None
+            self._fileno = None
+            self._protocol = None
             raise ValueError("Pipe transport is only for "
                              "pipes, sockets and character devices")
+
         _set_nonblocking(self._fileno)
-        self._protocol = protocol
-        self._buffer = []
-        self._conn_lost = 0
-        self._closing = False  # Set when close() or write_eof() called.
 
         self._loop.call_soon(self._protocol.connection_made, self)
 

--- a/examples/crawl.py
+++ b/examples/crawl.py
@@ -594,11 +594,12 @@ class Fetcher:
             stats.add('html')
             size = len(self.body or b'')
             stats.add('html_bytes', size)
-            print(self.url, self.response.status,
-                  self.ctype, self.encoding,
-                  size,
-                  '%d/%d' % (len(self.new_urls or ()), len(self.urls or ())),
-                  file=file)
+            if self.log.level:
+                print(self.url, self.response.status,
+                      self.ctype, self.encoding,
+                      size,
+                      '%d/%d' % (len(self.new_urls or ()), len(self.urls or ())),
+                      file=file)
         elif self.response is None:
             print(self.url, 'no response object')
         else:

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,16 @@
 #  - hg ci && hg push
 
 import os
+import sys
 try:
     from setuptools import setup, Extension
 except ImportError:
     # Use distutils.core as a fallback.
     # We won't be able to build the Wheel file on Windows.
     from distutils.core import setup, Extension
+
+if sys.version_info < (3, 3, 0):
+    raise RuntimeError("asyncio requires Python 3.3.0+")
 
 extensions = []
 if os.name == 'nt':


### PR DESCRIPTION
Here's a pull request designed to fix the issue reported in #368.

This commit re-orders the initialization code in the _UnixReadPipeTransport
and _UnixWritePipeTransport constructors to make sure all members are
assigned a value, even in the case where ValueError is raised due to
an incompatible type of pipe. This avoids exceptions being raised in
__repr__() due to the missing members.

In the case where ValueError is raised, this commit also clears the values
of _pipe, _fileno, and _protocol since this transport isn't returned,
avoiding a spurious "unclosed transport" warning when the object is
garbage-collected.