### PR TITLE
Set TCP_NODELAY on TCP transports by default

### DIFF
--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -39,6 +39,17 @@ def _test_selector_event(selector, fd, event):
         return bool(key.events & event)
 
 
+if hasattr(socket, 'TCP_NODELAY'):
+    def _set_nodelay(sock):
+        if (sock.family in {socket.AF_INET, socket.AF_INET6} and
+                sock.type == socket.SOCK_STREAM and
+                sock.proto == socket.IPPROTO_TCP):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+else:
+    def _set_nodelay(sock):
+        pass
+
+
 class BaseSelectorEventLoop(base_events.BaseEventLoop):
     """Selector event loop.
 
@@ -639,6 +650,11 @@ class _SelectorSocketTransport(_SelectorTransport):
         super().__init__(loop, sock, protocol, extra, server)
         self._eof = False
         self._paused = False
+
+        # Disable the Nagle algorithm -- small writes will be
+        # sent without waiting for the TCP ACK.  This generally
+        # decreases the latency (in some cases significantly.)
+        _set_nodelay(self._sock)
 
         self._loop.call_soon(self._protocol.connection_made, self)
         # only start reading when connection_made() has been called


### PR DESCRIPTION
This PR enables `TCP_NODELAY` for all TCP transports.