### PR TITLE
 Refuse handlers if the child watcher has no loop attached

### DIFF
--- a/asyncio/unix_events.py
+++ b/asyncio/unix_events.py
@@ -802,6 +802,11 @@ class SafeChildWatcher(BaseChildWatcher):
         pass
 
     def add_child_handler(self, pid, callback, *args):
+        if self._loop is None:
+            raise RuntimeError(
+                "Cannot add child handler, "
+                "the child watcher does not have a loop attached")
+
         self._callbacks[pid] = (callback, args)
 
         # Prevent a race condition in case the child is already terminated.
@@ -898,6 +903,12 @@ class FastChildWatcher(BaseChildWatcher):
 
     def add_child_handler(self, pid, callback, *args):
         assert self._forks, "Must use the context manager"
+
+        if self._loop is None:
+            raise RuntimeError(
+                "Cannot add child handler, "
+                "the child watcher does not have a loop attached")
+
         with self._lock:
             try:
                 returncode = self._zombies.pop(pid)

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -435,7 +435,8 @@ class SubprocessMixin:
 
         # Clear the handlers for FastChildWatcher to avoid a warning.
         # Is that a bug?
-        asyncio.get_child_watcher()._callbacks.clear()
+        if sys.platform != 'win32':
+            asyncio.get_child_watcher()._callbacks.clear()
 
     def test_popen_error(self):
         # Issue #24763: check that the subprocess transport is closed

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -433,6 +433,10 @@ class SubprocessMixin:
         # the transport was not notified yet
         self.assertFalse(killed)
 
+        # Clear the handlers for FastChildWatcher to avoid a warning.
+        # Is that a bug?
+        asyncio.get_child_watcher()._callbacks.clear()
+
     def test_popen_error(self):
         # Issue #24763: check that the subprocess transport is closed
         # when BaseSubprocessTransport fails

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -433,9 +433,11 @@ class SubprocessMixin:
         # the transport was not notified yet
         self.assertFalse(killed)
 
-        # Clear the handlers for FastChildWatcher to avoid a warning.
-        # Is that a bug?
-        if sys.platform != 'win32':
+        # Unlike SafeChildWatcher, FastChildWatcher does not pop the
+        # callbacks if waitpid() is called elsewhere. Let's clear them
+        # manually to avoid a warning when the watcher is detached.
+        if sys.platform != 'win32' and \
+           isinstance(self, SubprocessFastWatcherTests):
             asyncio.get_child_watcher()._callbacks.clear()
 
     def test_popen_error(self):

--- a/tests/test_unix_events.py
+++ b/tests/test_unix_events.py
@@ -1471,6 +1471,15 @@ class ChildWatcherTestsMixin:
                 if isinstance(self.watcher, asyncio.FastChildWatcher):
                     self.assertFalse(self.watcher._zombies)
 
+    @waitpid_mocks
+    def test_add_child_handler_with_no_loop_attached(self, m):
+        callback = mock.Mock()
+        with self.create_watcher() as watcher:
+            with self.assertRaisesRegex(
+                    RuntimeError,
+                    'the child watcher does not have a loop attached'):
+                watcher.add_child_handler(100, callback)
+
 
 class SafeChildWatcherTests (ChildWatcherTestsMixin, test_utils.TestCase):
     def create_watcher(self):

--- a/tests/test_unix_events.py
+++ b/tests/test_unix_events.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import threading
 import unittest
+import warnings
 from unittest import mock
 
 if sys.platform == 'win32':
@@ -1396,7 +1397,11 @@ class ChildWatcherTestsMixin:
         with mock.patch.object(
                 old_loop, "remove_signal_handler") as m_remove_signal_handler:
 
-            self.watcher.attach_loop(None)
+            with warnings.catch_warnings(record=True) as warns:
+                self.watcher.attach_loop(None)
+            self.assertEqual(len(warns), 1)
+            self.assertEqual(warns[0].category, RuntimeWarning)
+            self.assertIn('A loop is being detached', warns[0].message.args[0])
 
             m_remove_signal_handler.assert_called_once_with(
                 signal.SIGCHLD)

--- a/tests/test_unix_events.py
+++ b/tests/test_unix_events.py
@@ -1397,11 +1397,9 @@ class ChildWatcherTestsMixin:
         with mock.patch.object(
                 old_loop, "remove_signal_handler") as m_remove_signal_handler:
 
-            with warnings.catch_warnings(record=True) as warns:
+            with self.assertWarnsRegex(
+                    RuntimeWarning, 'A loop is being detached'):
                 self.watcher.attach_loop(None)
-            self.assertEqual(len(warns), 1)
-            self.assertEqual(warns[0].category, RuntimeWarning)
-            self.assertIn('A loop is being detached', warns[0].message.args[0])
 
             m_remove_signal_handler.assert_called_once_with(
                 signal.SIGCHLD)


### PR DESCRIPTION
This PR follows up on the discussion from issue #390:

- f348122 fixes the issue
- f7a5259 is a proposal and can easily be discarded

This has been tested against the [example](https://github.com/python/asyncio/issues/390#issuecomment-235871755) from issue #390.