### PR TITLE
Fix an unclosed transport error in test_events

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -793,7 +793,7 @@ class EventLoopTestsMixin:
             loop.connect_accepted_socket(
                 (lambda : proto), conn, ssl=server_ssl))
         loop.run_forever()
-        conn.close()
+        proto.transport.close()
         lsock.close()
 
         thread.join(1)


### PR DESCRIPTION
When running the asyncio unit tests, I noticed that I was seeing the
following error from test_ssl_connect_accepted_socket():

/Volumes/ronf/src/asyncio/asyncio/sslproto.py:328: ResourceWarning: unclosed transport <asyncio.sslproto._SSLProtocolTransport object at 0x10d7d57b8>
  warnings.warn("unclosed transport %r" % self, ResourceWarning)

This commit fixes this error by calling close on the transport which is
opened rather than calling close on the socket of the accepted
connection used to create it.