### PR TITLE
Add draining feature to asyncio.Queue

### DIFF
--- a/asyncio/queues.py
+++ b/asyncio/queues.py
@@ -1,14 +1,15 @@
 """Queues"""
 
-__all__ = ['Queue', 'PriorityQueue', 'LifoQueue', 'QueueFull', 'QueueEmpty']
+__all__ = ['Queue', 'PriorityQueue', 'LifoQueue',
+           'QueueFull', 'QueueEmpty', 'QueueClosed']
 
 import collections
 import heapq
 
 from . import compat
 from . import events
-from . import futures
 from . import locks
+from . import CancelledError
 from .coroutines import coroutine
 
 
@@ -16,14 +17,17 @@ class QueueEmpty(Exception):
     """Exception raised when Queue.get_nowait() is called on a Queue object
     which is empty.
     """
-    pass
 
 
 class QueueFull(Exception):
     """Exception raised when the Queue.put_nowait() method is called on a Queue
     object which is full.
     """
-    pass
+
+
+class QueueClosed(CancelledError):
+    """Exception raised by Queue.get() and Queue.put()
+    when Queue.close() or Queue.drain() is called"""
 
 
 class Queue:
@@ -47,12 +51,15 @@ class Queue:
 
         # Futures.
         self._getters = collections.deque()
-        # Futures.
         self._putters = collections.deque()
+        self._drainer = None
+
         self._unfinished_tasks = 0
         self._finished = locks.Event(loop=self._loop)
         self._finished.set()
         self._init(maxsize)
+        self.is_closed = False
+        self.is_draining = False
 
     # These three are overridable in subclasses.
 
@@ -74,6 +81,12 @@ class Queue:
             if not waiter.done():
                 waiter.set_result(None)
                 break
+
+    def _wakeup_all(self):
+        # wake up all waiters (if any) that aren't cancelled.
+        for waiters in (self._putters, self._getters):
+            while waiters:
+                self._wakeup_next(waiters)
 
     def __repr__(self):
         return '<{} at {:#x} {}>'.format(
@@ -128,6 +141,8 @@ class Queue:
         This method is a coroutine.
         """
         while self.full():
+            if self.is_closed or self.is_draining:
+                raise QueueClosed
             putter = self._loop.create_future()
             self._putters.append(putter)
             try:
@@ -146,6 +161,8 @@ class Queue:
 
         If no free slot is immediately available, raise QueueFull.
         """
+        if self.is_draining or self.is_closed:
+            raise QueueClosed
         if self.full():
             raise QueueFull
         self._put(item)
@@ -162,6 +179,16 @@ class Queue:
         This method is a coroutine.
         """
         while self.empty():
+            if self.is_closed:
+                raise QueueClosed
+            if self.is_draining:
+                if self._drainer:
+                    self._drainer.set_result(None)
+                    self._drainer = None
+                self.is_draining = False
+                self.is_closed = True
+                raise QueueClosed
+
             getter = self._loop.create_future()
             self._getters.append(getter)
             try:
@@ -180,6 +207,8 @@ class Queue:
 
         Return an item if one is immediately available, else raise QueueEmpty.
         """
+        if self.is_closed:
+            raise QueueClosed
         if self.empty():
             raise QueueEmpty
         item = self._get()
@@ -217,6 +246,45 @@ class Queue:
         """
         if self._unfinished_tasks > 0:
             yield from self._finished.wait()
+
+    @coroutine
+    def drain(self):
+        """ Closes the queue and lets the queue drain.
+        Waits until queue is empty before returning.
+
+        Any following calls to Queue.put() or Queue.put_nowait() will raise
+        a QueueClosed Exception. Following calls to Queue.get() will succeed
+        until the queue is empty. Once the queue is empty, Queue.get() will
+        raise a QueueClosed exception.
+
+        Raises QueueClosed if the queue is already being drained or is closed.
+        """
+        if self.is_draining:
+            raise QueueClosed
+        self.drain_nowait()
+        yield from self.join()
+
+    def drain_nowait(self):
+        """Closes the queue and lets the queue drain.
+        Does not wait for the queue to be drained before returning.
+        """
+        if self.empty():
+            self.is_draining = False
+            self.is_closed = True
+        else:
+            self.is_draining = True
+
+        self._wakeup_all()
+
+    def close(self):
+        """ Closes the queue immediately, preventing all puts or gets.
+
+        Any call to Queue.get(), Queue.put(), or Queue.put_nowait() will
+        raise a QueueClosed exception.
+        """
+        self.is_closed = True
+        self.is_draining = False
+        self._wakeup_all()
 
 
 class PriorityQueue(Queue):


### PR DESCRIPTION
This feature adds the ability to drain a Queue. This is useful for cleanup steps, especially in the simple websocket case.

It adds the following things:
- (coroutine) drain - waits until the queue is drained, errors on puts, errors on gets once queue is empty
- drain_nowait
- close - closes queue immediately, errors on all gets and puts

Imagine we have the following code:

``` python
import asyncio
q = asyncio.Queue()

async def wait_for_it():
        while True:
            t = await q.get()
            q.task_done()


loop = asyncio.get_event_loop()
asyncio.ensure_future(wait_for_it())

try:
    loop.run_forever()
except KeyboardInterrupt:
    pass
```

This actually creates a lot of warnings/errors on shutdown, such as

```
Task was destroyed but it is pending!
task: <Task pending coro=<wait_for_it() running at test.py:6> wait_for=<Future pending cb=[Task._wakeup()]>>
Exception ignored in: <coroutine object wait_for_it at 0x7f594abb7830>
Traceback (most recent call last):
  File "test.py", line 6, in wait_for_it
  File "/usr/lib/python3.5/asyncio/queues.py", line 170, in get
  File "/usr/lib/python3.5/asyncio/futures.py", line 227, in cancel
  File "/usr/lib/python3.5/asyncio/futures.py", line 242, in _schedule_callbacks
  File "/usr/lib/python3.5/asyncio/base_events.py", line 497, in call_soon
  File "/usr/lib/python3.5/asyncio/base_events.py", line 506, in _call_soon
  File "/usr/lib/python3.5/asyncio/base_events.py", line 334, in _check_closed
RuntimeError: Event loop is closed
```

The fix is 

``` python
import asyncio

q = asyncio.Queue()

async def wait_for_it():
        while True:
            t = await q.get()
            q.task_done()


loop = asyncio.get_event_loop()
task = loop.create_task(wait_for_it())

try:
    loop.run_forever()
except KeyboardInterrupt:
    pass
finally:
    task.cancel()
    pending = asyncio.Task.all_tasks()
    try:
        loop.run_until_complete(asyncio.gather(*pending))
    except asyncio.CancelledError:
        print('expected')
    loop.close()
```

which is very unwieldy and not obvious.

Instead I propose a drain feature which gives us the following code

``` python
import asyncio

q = asyncio.Queue()

async def wait_for_it():
    try:
        while True:
            t = await q.get()
            q.task_done()
    except asyncio.QueueClosed:
        print('closed')


loop = asyncio.get_event_loop()
asyncio.ensure_future(wait_for_it())
asyncio.ensure_future(wait_for_it())

try:
    loop.run_forever()
except KeyboardInterrupt:
    pass
finally:
    loop.run_until_complete(q.drain())
    loop.close()
```

which is much cleaner and simple.
