### PR TITLE
Check to see if SO_REUSEPORT is usable and not just defined.

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -90,10 +90,13 @@ if hasattr(socket, 'SOCK_CLOEXEC'):
 _HAS_SO_REUSEPORT = False
 if hasattr(socket, "SO_REUSEPORT"):
     try:
-        socket.setsockopt(socket.socket(), socket.SO_REUSEPORT, 1)
+        _sock = socket.socket()
+        _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         _HAS_SO_REUSEPORT = True
     except OSError:
         pass
+    finally:
+        _sock = None
       
 
 def _ipaddr_info(host, port, family, type, proto):

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -82,22 +82,6 @@ if hasattr(socket, 'SOCK_NONBLOCK'):
     _SOCKET_TYPE_MASK |= socket.SOCK_NONBLOCK
 if hasattr(socket, 'SOCK_CLOEXEC'):
     _SOCKET_TYPE_MASK |= socket.SOCK_CLOEXEC
-    
-    
-# Tests to see if SO_REUSEPORT is both defined and usable as
-# some platforms define SO_REUSEPORT but do not implement it.
-# See Python issue 26858 for more info: http://bugs.python.org/issue26858
-_HAS_USABLE_SO_REUSEPORT = False
-if hasattr(socket, "SO_REUSEPORT"):
-    try:
-        _sock = socket.socket()
-        _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        _HAS_USABLE_SO_REUSEPORT = True
-    except OSError:
-        pass
-    finally:
-        _sock.close()
-        _sock = None
       
 
 def _ipaddr_info(host, port, family, type, proto):
@@ -830,13 +814,17 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     if reuse_port:
-                        if (not _HAS_USABLE_SO_REUSEPORT or 
-                            not hasattr(socket, "SO_REUSEPORT")):
+                        if not hasattr(socket, "SO_REUSEPORT"):
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:
-                            sock.setsockopt(
-                                socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                            try:
+                                sock.setsockopt(
+                                    socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                            except OSError:
+                                raise ValueError((
+                                    'reuse_port not supported by socket module, '
+                                    'SO_REUSEPORT defined but not implemented.'))
                     if allow_broadcast:
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
@@ -959,13 +947,17 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
                     if reuse_port:
-                        if (not _HAS_USABLE_SO_REUSEPORT or 
-                            not hasattr(socket, "SO_REUSEPORT")):
+                        if not hasattr(socket, "SO_REUSEPORT"):
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:
-                            sock.setsockopt(
-                                socket.SOL_SOCKET, socket.SO_REUSEPORT, True)
+                            try:
+                                sock.setsockopt(
+                                    socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                            except OSError:
+                                raise ValueError((
+                                    'reuse_port not supported by socket module, '
+                                    'SO_REUSEPORT defined but not implemented.'))
                     # Disable IPv4/IPv6 dual stack support (enabled by
                     # default on Linux) which makes a single socket
                     # listen on both address families.

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -87,12 +87,12 @@ if hasattr(socket, 'SOCK_CLOEXEC'):
 # Tests to see if SO_REUSEPORT is both defined and usable.
 # as some platforms define SO_REUSEPORT but do not implement it.
 # See Python issue 26858 for more info: http://bugs.python.org/issue26858
-_HAS_SO_REUSEPORT = False
+_HAS_USABLE_SO_REUSEPORT = False
 if hasattr(socket, "SO_REUSEPORT"):
     try:
         _sock = socket.socket()
         _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        _HAS_SO_REUSEPORT = True
+        _HAS_USABLE_SO_REUSEPORT = True
     except OSError:
         pass
     finally:
@@ -830,7 +830,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     if reuse_port:
-                        if not _HAS_SO_REUSEPORT:
+                        if not hasattr(socket, "SO_REUSEPORT") or not _HAS_USABLE_SO_REUSEPORT:
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:
@@ -958,7 +958,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
                     if reuse_port:
-                        if not _HAS_SO_REUSEPORT:
+                        if not hasattr(socket, "SO_REUSEPORT") or not _HAS_USABLE_SO_REUSEPORT:
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -96,6 +96,7 @@ if hasattr(socket, "SO_REUSEPORT"):
     except OSError:
         pass
     finally:
+        _sock.close()
         _sock = None
       
 
@@ -957,7 +958,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
                     if reuse_port:
-                        if not hasattr(socket, 'SO_REUSEPORT'):
+                        if not _HAS_SO_REUSEPORT:
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -84,8 +84,8 @@ if hasattr(socket, 'SOCK_CLOEXEC'):
     _SOCKET_TYPE_MASK |= socket.SOCK_CLOEXEC
     
     
-# Tests to see if SO_REUSEPORT is both defined and usable.
-# as some platforms define SO_REUSEPORT but do not implement it.
+# Tests to see if SO_REUSEPORT is both defined and usable as
+# some platforms define SO_REUSEPORT but do not implement it.
 # See Python issue 26858 for more info: http://bugs.python.org/issue26858
 _HAS_USABLE_SO_REUSEPORT = False
 if hasattr(socket, "SO_REUSEPORT"):

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -830,7 +830,8 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     if reuse_port:
-                        if not hasattr(socket, "SO_REUSEPORT") or not _HAS_USABLE_SO_REUSEPORT:
+                        if not hasattr(socket, "SO_REUSEPORT") or \
+                           not _HAS_USABLE_SO_REUSEPORT:
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:
@@ -958,7 +959,8 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
                     if reuse_port:
-                        if not hasattr(socket, "SO_REUSEPORT") or not _HAS_USABLE_SO_REUSEPORT:
+                        if not hasattr(socket, "SO_REUSEPORT") or \
+                           not _HAS_USABLE_SO_REUSEPORT:
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -830,8 +830,8 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     if reuse_port:
-                        if not hasattr(socket, "SO_REUSEPORT") or \
-                           not _HAS_USABLE_SO_REUSEPORT:
+                        if (not _HAS_USABLE_SO_REUSEPORT or 
+                            not hasattr(socket, "SO_REUSEPORT")):
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:
@@ -959,8 +959,8 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
                     if reuse_port:
-                        if not hasattr(socket, "SO_REUSEPORT") or \
-                           not _HAS_USABLE_SO_REUSEPORT:
+                        if (not _HAS_USABLE_SO_REUSEPORT or 
+                            not hasattr(socket, "SO_REUSEPORT")):
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:

--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -82,7 +82,7 @@ if hasattr(socket, 'SOCK_NONBLOCK'):
     _SOCKET_TYPE_MASK |= socket.SOCK_NONBLOCK
 if hasattr(socket, 'SOCK_CLOEXEC'):
     _SOCKET_TYPE_MASK |= socket.SOCK_CLOEXEC
-      
+
 
 def _ipaddr_info(host, port, family, type, proto):
     # Try to skip getaddrinfo if "host" is already an IP. Users might have
@@ -814,7 +814,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     if reuse_port:
-                        if not hasattr(socket, "SO_REUSEPORT"):
+                        if not hasattr(socket, 'SO_REUSEPORT'):
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:
@@ -947,7 +947,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
                     if reuse_port:
-                        if not hasattr(socket, "SO_REUSEPORT"):
+                        if not hasattr(socket, 'SO_REUSEPORT'):
                             raise ValueError(
                                 'reuse_port not supported by socket module')
                         else:

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -1371,6 +1371,17 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertRaises(ValueError, self.loop.run_until_complete, f)
 
     @patch_socket
+    def test_create_server_soreuseport_only_defined(self, m_socket):
+        m_socket.getaddrinfo = socket.getaddrinfo
+        m_socket.socket.return_value = mock.Mock()
+        m_socket.SO_REUSEPORT = -1
+
+        f = self.loop.create_server(
+            MyProto, '0.0.0.0', 0, reuse_port=True)
+
+        self.assertRaises(ValueError, self.loop.run_until_complete, f)
+
+    @patch_socket
     def test_create_server_cant_bind(self, m_socket):
 
         class Err(OSError):

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -36,7 +36,7 @@ def mock_socket_module():
     m_socket = mock.MagicMock(spec=socket)
     for name in (
         'AF_INET', 'AF_INET6', 'AF_UNSPEC', 'IPPROTO_TCP', 'IPPROTO_UDP',
-        'SOCK_STREAM', 'SOCK_DGRAM', 'SOL_SOCKET', 'SO_REUSEADDR', 'inet_pton'
+        'SOCK_STREAM', 'SOCK_DGRAM', 'SOL_SOCKET', 'SO_REUSEADDR', 'SO_REUSEPORT', 'inet_pton'
     ):
         if hasattr(socket, name):
             setattr(m_socket, name, getattr(socket, name))

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -36,7 +36,7 @@ def mock_socket_module():
     m_socket = mock.MagicMock(spec=socket)
     for name in (
         'AF_INET', 'AF_INET6', 'AF_UNSPEC', 'IPPROTO_TCP', 'IPPROTO_UDP',
-        'SOCK_STREAM', 'SOCK_DGRAM', 'SOL_SOCKET', 'SO_REUSEADDR', 'SO_REUSEPORT', 'inet_pton'
+        'SOCK_STREAM', 'SOCK_DGRAM', 'SOL_SOCKET', 'SO_REUSEADDR', 'inet_pton'
     ):
         if hasattr(socket, name):
             setattr(m_socket, name, getattr(socket, name))

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -1362,8 +1362,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
     @patch_socket
     def test_create_server_nosoreuseport(self, m_socket):
         m_socket.getaddrinfo = socket.getaddrinfo
-        if hasattr(m_socket, "SO_REUSEPORT"):
-            del m_socket.SO_REUSEPORT
+        del m_socket.SO_REUSEPORT
         m_socket.socket.return_value = mock.Mock()
 
         f = self.loop.create_server(
@@ -1575,8 +1574,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
 
     @patch_socket
     def test_create_datagram_endpoint_nosoreuseport(self, m_socket):
-        if hasattr(m_socket, "SO_REUSEPORT"):
-            del m_socket.SO_REUSEPORT
+        del m_socket.SO_REUSEPORT
         m_socket.socket.return_value = mock.Mock()
 
         coro = self.loop.create_datagram_endpoint(

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -1362,7 +1362,8 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
     @patch_socket
     def test_create_server_nosoreuseport(self, m_socket):
         m_socket.getaddrinfo = socket.getaddrinfo
-        del m_socket.SO_REUSEPORT
+        if hasattr(m_socket, "SO_REUSEPORT"):
+            del m_socket.SO_REUSEPORT
         m_socket.socket.return_value = mock.Mock()
 
         f = self.loop.create_server(
@@ -1574,7 +1575,8 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
 
     @patch_socket
     def test_create_datagram_endpoint_nosoreuseport(self, m_socket):
-        del m_socket.SO_REUSEPORT
+        if hasattr(m_socket, "SO_REUSEPORT"):
+            del m_socket.SO_REUSEPORT
         m_socket.socket.return_value = mock.Mock()
 
         coro = self.loop.create_datagram_endpoint(


### PR DESCRIPTION
Some platforms define SO_REUSEPORT but do not implement it, resulting in cryptic OSErrors when trying to use socket.SO_REUSEPORT. This PR would solve that issue for all platforms that implement but don't define a usable SO_REUSEPORT. More info in [Python issue 26858](http://bugs.python.org/issue26858). See issue #352 .

Edit: I have signed the PSF Contributor Agreement
