### PR TITLE
make CoroWrapper.throw fully compatible with gen.throw

### DIFF
--- a/asyncio/coroutines.py
+++ b/asyncio/coroutines.py
@@ -120,8 +120,8 @@ class CoroWrapper:
         def send(self, value):
             return self.gen.send(value)
 
-    def throw(self, exc):
-        return self.gen.throw(exc)
+    def throw(self, type, value=None, traceback=None):
+        return self.gen.throw(type, value, traceback)
 
     def close(self):
         return self.gen.close()


### PR DESCRIPTION
Following #429, this PR makes the signature of CoroWrapper.throw compatible with gen.throw.

The signature of gen.throw is the same in python 3.3 - 3.5. Unless I'm missing something, the patch shouldn't change anything for the current implementation of asyncio, since throw is only called explicitly in Task:
https://github.com/python/asyncio/blob/master/asyncio/tasks.py#L241