### PR TITLE
Trim off finished futures from the Event._waiters

### DIFF
--- a/asyncio/locks.py
+++ b/asyncio/locks.py
@@ -264,8 +264,12 @@ class Event:
             yield from fut
             return True
         finally:
-            self._waiters.remove(fut)
-
+            # popleft all finished futures up to the first pending one
+            while self._waiters:
+                if not self._waiters[0].done():
+                    break
+                else:
+                    self._waiters.popleft()
 
 class Condition(_ContextManagerMixin):
     """Asynchronous equivalent to threading.Condition.


### PR DESCRIPTION
Current implementation of Event.wait uses dequeue.remove(e),
wich has O(n) complexity. We can do better by utilizing this
time to also remove all finished futures from the queue
on the way up until we reach the future that is in a pending
state. This will make subsequent calls to Event.wait or
Event.set to perform less work on a waiters queue