### PR TITLE
Document gather's undeterministic scheduling of awaitables and coroutines

### DIFF
--- a/asyncio/tasks.py
+++ b/asyncio/tasks.py
@@ -594,6 +594,10 @@ def gather(*coros_or_futures, loop=None, return_exceptions=False):
     """Return a future aggregating results from the given coroutines
     or futures.
 
+    Coroutines will be wrapped in a future and scheduled in the event
+    loop. They will not necessarily be scheduled in the same order as
+    passed in.
+
     All futures must share the same event loop.  If all the tasks are
     done successfully, the returned future's result is the list of
     results (in the order of the original sequence, not necessarily


### PR DESCRIPTION
Resolves #432. This is probably the best performing solution. The workaround for a programmer that wishes their coroutine objects to be undertaken in a deterministic order is for them to schedule the execution on the loop themselves with `asyncio.ensure_future` or `loop.create_task` before calling `asyncio.gather`.