### PR TITLE
Ensure order of tasks scheduled on event loop by gather is deterministic.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Guido van Rossum <guido AT python.org>: creator of the asyncio project and autho
 Gustavo Carneiro <gjcarneiro AT gmail.com>
 Jeff Quast
 Jonathan Slenders <jonathan.slenders AT gmail.com>
+Justin Turner Arthur <justinarthur AT gmail.com>
 Nikolay Kim <fafhrd91 AT gmail.com>
 Richard Oudkerk <shibturn AT gmail.com>
 Saúl Ibarra Corretgé <saghul AT gmail.com>

--- a/asyncio/tasks.py
+++ b/asyncio/tasks.py
@@ -618,7 +618,11 @@ def gather(*coros_or_futures, loop=None, return_exceptions=False):
         return outer
 
     arg_to_fut = {}
-    for arg in set(coros_or_futures):
+    seen_args = set()
+    seen_args_add = seen_args.add
+    for arg in coros_or_futures:
+        if arg in seen_args or seen_args_add(arg):
+            continue
         if not futures.isfuture(arg):
             fut = ensure_future(arg, loop=loop)
             if loop is None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2082,6 +2082,20 @@ class CoroutineGatherTests(GatherTestsBase, test_utils.TestCase):
         self._run_loop(self.one_loop)
         self.assertEqual(fut.result(), ['abc', 'abc', 'def', 'abc'])
 
+    def test_coroutine_execution_order(self):
+        order = []
+        coro = asyncio.coroutine(order.append)
+        asyncio.gather(coro(1), coro(2), coro(3), coro(4), coro(5))
+        self._run_loop(self.one_loop)
+        self.assertEqual(order, [1, 2, 3, 4, 5])
+
+        order_after_dedupe = []
+        coro = asyncio.coroutine(order_after_dedupe.append)
+        c1 = coro(1)
+        asyncio.gather(c1, coro(2), c1, coro(3), coro(4), coro(5))
+        self._run_loop(self.one_loop)
+        self.assertEqual(order_after_dedupe, [1, 2, 3, 4, 5])
+
     def test_cancellation_broadcast(self):
         # Cancelling outer() cancels all children.
         proof = 0


### PR DESCRIPTION
Resolves #432. Likely a wee bit slower in most Python implementations as before this change, the interpreter had no obligation to order when uniqueness was established via a simple construction of a `set`. However, the programmer can now achieve a predictable order of scheduling (and possibly execution) of their awaitables or coroutines.