### PR TITLE
Use staticmethod or module function when instance isn't referenced.

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -76,6 +76,20 @@ def _format_pipe(fd):
         return repr(fd)
 
 
+def _log_subprocess(msg, stdin, stdout, stderr):
+    info = [msg]
+    if stdin is not None:
+        info.append('stdin=%s' % _format_pipe(stdin))
+    if stdout is not None and stderr == subprocess.STDOUT:
+        info.append('stdout=stderr=%s' % _format_pipe(stdout))
+    else:
+        if stdout is not None:
+            info.append('stdout=%s' % _format_pipe(stdout))
+        if stderr is not None:
+            info.append('stderr=%s' % _format_pipe(stderr))
+    logger.debug(' '.join(info))
+
+
 def _set_reuseport(sock):
     if not hasattr(socket, 'SO_REUSEPORT'):
         raise ValueError('reuse_port not supported by socket module')
@@ -227,6 +241,9 @@ class Server(events.AbstractServer):
         waiter = self._loop.create_future()
         self._waiters.append(waiter)
         yield from waiter
+
+
+_AF_INET6 = getattr(socket, 'AF_INET6', 0)
 
 
 class BaseEventLoop(events.AbstractEventLoop):
@@ -971,7 +988,6 @@ class BaseEventLoop(events.AbstractEventLoop):
                 raise ValueError(
                     'host/port and sock can not be specified at the same time')
 
-            AF_INET6 = getattr(socket, 'AF_INET6', 0)
             if reuse_address is None:
                 reuse_address = os.name == 'posix' and sys.platform != 'cygwin'
             sockets = []
@@ -1011,7 +1027,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                     # Disable IPv4/IPv6 dual stack support (enabled by
                     # default on Linux) which makes a single socket
                     # listen on both address families.
-                    if af == AF_INET6 and hasattr(socket, 'IPPROTO_IPV6'):
+                    if af == _AF_INET6 and hasattr(socket, 'IPPROTO_IPV6'):
                         sock.setsockopt(socket.IPPROTO_IPV6,
                                         socket.IPV6_V6ONLY,
                                         True)
@@ -1093,18 +1109,6 @@ class BaseEventLoop(events.AbstractEventLoop):
                          pipe.fileno(), transport, protocol)
         return transport, protocol
 
-    def _log_subprocess(self, msg, stdin, stdout, stderr):
-        info = [msg]
-        if stdin is not None:
-            info.append('stdin=%s' % _format_pipe(stdin))
-        if stdout is not None and stderr == subprocess.STDOUT:
-            info.append('stdout=stderr=%s' % _format_pipe(stdout))
-        else:
-            if stdout is not None:
-                info.append('stdout=%s' % _format_pipe(stdout))
-            if stderr is not None:
-                info.append('stderr=%s' % _format_pipe(stderr))
-        logger.debug(' '.join(info))
 
     @coroutine
     def subprocess_shell(self, protocol_factory, cmd, *, stdin=subprocess.PIPE,
@@ -1124,7 +1128,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             # don't log parameters: they may contain sensitive information
             # (password) and may be too long
             debug_log = 'run shell command %r' % cmd
-            self._log_subprocess(debug_log, stdin, stdout, stderr)
+            _log_subprocess(debug_log, stdin, stdout, stderr)
         transport = yield from self._make_subprocess_transport(
             protocol, cmd, True, stdin, stdout, stderr, bufsize, **kwargs)
         if self._debug:
@@ -1153,7 +1157,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             # don't log parameters: they may contain sensitive information
             # (password) and may be too long
             debug_log = 'execute program %r' % program
-            self._log_subprocess(debug_log, stdin, stdout, stderr)
+            _log_subprocess(debug_log, stdin, stdout, stderr)
         transport = yield from self._make_subprocess_transport(
             protocol, popen_args, False, stdin, stdout, stderr,
             bufsize, **kwargs)

--- a/asyncio/queues.py
+++ b/asyncio/queues.py
@@ -67,7 +67,8 @@ class Queue:
 
     # End of the overridable methods.
 
-    def _wakeup_next(self, waiters):
+    @staticmethod
+    def _wakeup_next(waiters):
         # Wake up the next waiter (if any) that isn't cancelled.
         while waiters:
             waiter = waiters.popleft()

--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -440,7 +440,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
     def _sock_connect_done(self, fd, fut):
         self.remove_writer(fd)
 
-    def _sock_connect_cb(self, fut, sock, address):
+    @staticmethod
+    def _sock_connect_cb(fut, sock, address):
         if fut.cancelled():
             return
 

--- a/asyncio/selectors.py
+++ b/asyncio/selectors.py
@@ -310,7 +310,8 @@ class SelectSelector(_BaseSelectorImpl):
         return key
 
     if sys.platform == 'win32':
-        def _select(self, r, w, _, timeout=None):
+        @staticmethod
+        def _select(r, w, _, timeout=None):
             r, w, x = select.select(r, w, w, timeout)
             return r, w + x, []
     else:

--- a/asyncio/windows_events.py
+++ b/asyncio/windows_events.py
@@ -388,6 +388,12 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
         return transp
 
 
+def _get_accept_socket(family):
+    s = socket.socket(family)
+    s.settimeout(0)
+    return s
+
+
 class IocpProactor:
     """Proactor implementation using IOCP."""
 
@@ -464,7 +470,7 @@ class IocpProactor:
 
     def accept(self, listener):
         self._register_with_iocp(listener)
-        conn = self._get_accept_socket(listener.family)
+        conn = _get_accept_socket(listener.family)
         ov = _overlapped.Overlapped(NULL)
         ov.AcceptEx(listener.fileno(), conn.fileno())
 
@@ -646,11 +652,6 @@ class IocpProactor:
         safe if the event is never signalled (because it was cancelled).
         """
         self._unregistered.append(ov)
-
-    def _get_accept_socket(self, family):
-        s = socket.socket(family)
-        s.settimeout(0)
-        return s
 
     def _poll(self, timeout=None):
         if timeout is None:


### PR DESCRIPTION
I used `staticmethod`s where I thought the taxonomy or overridability might be useful, or I didn't know.