### PR TITLE
starttls: Add "call_connection_made" arg to SSLProtocol.__init__

### DIFF
--- a/asyncio/sslproto.py
+++ b/asyncio/sslproto.py
@@ -410,7 +410,8 @@ class SSLProtocol(protocols.Protocol):
     """
 
     def __init__(self, loop, app_protocol, sslcontext, waiter,
-                 server_side=False, server_hostname=None):
+                 server_side=False, server_hostname=None,
+                 call_connection_made=True):
         if ssl is None:
             raise RuntimeError('stdlib ssl module not available')
 
@@ -443,6 +444,7 @@ class SSLProtocol(protocols.Protocol):
         self._in_shutdown = False
         # transport, ex: SelectorSocketTransport
         self._transport = None
+        self._call_connection_made = call_connection_made
 
     def _wakeup_waiter(self, exc=None):
         if self._waiter is None:
@@ -606,7 +608,8 @@ class SSLProtocol(protocols.Protocol):
                            compression=sslobj.compression(),
                            ssl_object=sslobj,
                            )
-        self._app_protocol.connection_made(self._app_transport)
+        if self._call_connection_made:
+            self._app_protocol.connection_made(self._app_transport)
         self._wakeup_waiter()
         self._session_established = True
         # In case transport.write() was already called. Don't call


### PR DESCRIPTION
This is the key modification of `sslproto.py` required to implement starttls. With this patch in place, we can implement starttls as an external package without copying/pasting of `sslproto.py`.

The patch is super small and non-invasive, only adding an extra argument to `SSLProtocol.__init__` (everything inside `sslproto.py` is an implementation detail of asyncio).