### PR TITLE
Implement __aiter__ protocol on a Queue

### DIFF
--- a/asyncio/queues.py
+++ b/asyncio/queues.py
@@ -9,6 +9,7 @@ from . import compat
 from . import events
 from . import locks
 from .coroutines import coroutine
+from .futures import CancelledError
 
 
 class QueueEmpty(Exception):
@@ -80,6 +81,16 @@ class Queue:
 
     def __str__(self):
         return '<{} {}>'.format(type(self).__name__, self._format())
+
+    def __aiter__(self):
+        return self
+
+    @coroutine
+    def __anext__(self):
+        try:
+            return (yield from self.get())
+        except CancelledError:
+            raise StopAsyncIteration
 
     def _format(self):
         result = 'maxsize={!r}'.format(self._maxsize)

--- a/asyncio/queues.py
+++ b/asyncio/queues.py
@@ -11,6 +11,8 @@ from . import locks
 from .coroutines import coroutine
 from .futures import CancelledError
 
+END_QUEUE = object()
+
 
 class QueueEmpty(Exception):
     """Exception raised when Queue.get_nowait() is called on a Queue object
@@ -87,10 +89,10 @@ class Queue:
 
     @coroutine
     def __anext__(self):
-        try:
-            return (yield from self.get())
-        except CancelledError:
+        val = yield from self.get()
+        if val is END_QUEUE:
             raise StopAsyncIteration
+        return val
 
     def _format(self):
         result = 'maxsize={!r}'.format(self._maxsize)

--- a/asyncio/queues.py
+++ b/asyncio/queues.py
@@ -9,7 +9,6 @@ from . import compat
 from . import events
 from . import locks
 from .coroutines import coroutine
-from .futures import CancelledError
 
 END_QUEUE = object()
 

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -227,5 +227,27 @@ class CoroutineTests(BaseTest):
             self.loop.run_until_complete(runner())
 
 
+class QueueAsyncIteratorTests(BaseTest):
+    def test_get_iter(self):
+        async def iter_consumer(queue, num_expected):
+            cnt = 0
+            async for item in queue:
+                cnt += 1
+                if cnt == num_expected:
+                    break
+
+        async def producer(queue, num_items):
+            for i in range(num_items):
+                await queue.put(i)
+
+        q = asyncio.Queue(loop=self.loop)
+        num_items = 5
+        self.loop.run_until_complete(
+            asyncio.gather(producer(q, 5),
+                           iter_consumer(q, 5),
+                           loop=self.loop),
+            )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Many times when using asycio.Queue a task is created to process the queue continually, resulting in code such as this:

```
while True:
    val = await q.get()
    # do stuff with val
    q.task_done()
```

Which feels less than ideal for a few reasons:

* There is not a good wait to determine when the queue is done, unless the producer/consumer decide on a sentinel ahead of time or the task is explicitly cancelled.
* It doesn't read as cleanly as most python code :)

Instead in many cases it would feel more pythonic to iterate the results of a queue in a task:

```
async for val in q:
    # do stuff with val
    q.task_done()
```

It doesn't substantially change the LOC, but it does, in my opinion, read a little more fluidly.

This does open up a few questions on how, and when, to raise `StopAsyncIteration`:

1. There is no queue.close/quit/etc, so we cannot set an event on that
2. Relying on `__del__` didn't feel right, while it works with scope - using it manually feels wrong and it obviously kills the queue you may otherwise plan to continue using - among other questions in an async env.
3. `join` could be used to synchronize processing before continuing to be used again - and thus cannot be reliably used to suggest the iterator should discontinue consuming.
4. The intended usage of `_finished` appears to be, and I may be misunderstanding, primarily around whether or not there is data at that moment, not if the queue is fully closed (I picture a case in which a consumer consumes faster than a producer produces)

That leaves me with a few options that seem reasonable (with various implementations):

* Use a sentinel (as this PR shows): I am not 100% sure I like this as it leaks the implementation out more than I think I like (but wanted your opinions).
* Add a method on the queue to use the sentinel idea internally (I haven't thought of a good name yet...)

Outstanding questions:

* I don't believe that `join` should set this value, since a producer could call `q.join(); q.put(queues.END_QUEUE)` (basically saying we wouldn't need to make this decision for them)
* Should this instead be a method and a specific sentinel per queue?
* Naming may be suspect, perhaps there is a better name for the sentinel value (or maybe we don't expose it and instead use the method approach).
* In the case of multiple producers, there is possibly question as they may now be dumping to a queue that is no longer being consumed.

This may not be the best implementation, however I wanted to start a conversation around it as it has, thus far, been nice in a side project and others were encouraging me to. Granted our case is limited and instead I could put this in an external lib.

If you like the method idea instead and have a good name idea - I am at a loss at the moment...