### PR TITLE
Handle if async generators are GCed from another thread.

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -351,6 +351,9 @@ class BaseEventLoop(events.AbstractEventLoop):
         self._asyncgens.discard(agen)
         if not self.is_closed():
             self.create_task(agen.aclose())
+            # Wake up the loop if the finalizer was called from
+            # a different thread.
+            self._write_to_self()
 
     def _asyncgen_firstiter_hook(self, agen):
         if self._asyncgens_shutdown_called:


### PR DESCRIPTION
`_asyncgen_finalizer_hook` should wake up the loop in case it was called from another thread.