### PR TITLE
Detach socket in create_server, create_connection, and other APIs

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -87,6 +87,12 @@ def _set_reuseport(sock):
                              'SO_REUSEPORT defined but not implemented.')
 
 
+def _copy_and_detach_socket(sock):
+    new_sock = socket.socket(sock.family, sock.type, sock.proto, sock.fileno())
+    sock.detach()
+    return new_sock
+
+
 # Linux's sock.type is a bitmask that can include extra info about socket.
 _SOCKET_TYPE_MASK = 0
 if hasattr(socket, 'SOCK_NONBLOCK'):
@@ -768,9 +774,11 @@ class BaseEventLoop(events.AbstractEventLoop):
                     raise OSError('Multiple exceptions: {}'.format(
                         ', '.join(str(exc) for exc in exceptions)))
 
-        elif sock is None:
-            raise ValueError(
-                'host and port was not specified and no sock specified')
+        else:
+            if sock is None:
+                raise ValueError(
+                    'host and port was not specified and no sock specified')
+            sock = _copy_and_detach_socket(sock)
 
         transport, protocol = yield from self._create_connection_transport(
             sock, protocol_factory, ssl, server_hostname)
@@ -827,6 +835,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                 raise ValueError(
                     'socket modifier keyword arguments can not be used '
                     'when sock is specified. ({})'.format(problems))
+            sock = _copy_and_detach_socket(sock)
             sock.setblocking(False)
             r_addr = None
         else:
@@ -1024,6 +1033,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         else:
             if sock is None:
                 raise ValueError('Neither host/port nor sock were specified')
+            sock = _copy_and_detach_socket(sock)
             sockets = [sock]
 
         server = Server(self, sockets)
@@ -1045,6 +1055,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         This method is a coroutine.  When completed, the coroutine
         returns a (transport, protocol) pair.
         """
+        sock = _copy_and_detach_socket(sock)
         transport, protocol = yield from self._create_connection_transport(
             sock, protocol_factory, ssl, '', server_side=True)
         if self._debug:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1240,11 +1240,12 @@ class EventLoopTestsMixin:
         sock_ob = socket.socket(type=socket.SOCK_STREAM)
         sock_ob.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock_ob.bind(('0.0.0.0', 0))
+        sock_ob_fd = sock_ob.fileno()
 
         f = self.loop.create_server(TestMyProto, sock=sock_ob)
         server = self.loop.run_until_complete(f)
         sock = server.sockets[0]
-        self.assertIs(sock, sock_ob)
+        self.assertEqual(sock.fileno(), sock_ob_fd)
 
         host, port = sock.getsockname()
         self.assertEqual(host, '0.0.0.0')

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -582,7 +582,7 @@ class StreamReaderTests(test_utils.TestCase):
                     asyncio.start_server(self.handle_client,
                                          sock=sock,
                                          loop=self.loop))
-                return sock.getsockname()
+                return self.server.sockets[0].getsockname()
 
             def handle_client_callback(self, client_reader, client_writer):
                 self.loop.create_task(self.handle_client(client_reader,


### PR DESCRIPTION
#### Target

Python 3.6b3

#### Background

In Python 3.6, `socket.close()` method will propagate any `OSError` from the underlying syscall (see [issue #26685](http://bugs.python.org/issue26685) for details.)

What it means for alternative implementations of asyncio event loop, such as uvloop is that programs that run on Python 3.5 may become broken on Python 3.6. Consider the following example:

```python
sock = socket.socket()
sock.bind(('127.0.0.1', 0))
srv = loop.run_until_complete(
    loop.create_server(protocol_factory, sock=sock))
try:
    loop.run_forever()
finally:
    srv.close()
    loop.run_until_complete(srv.wait_closed())

    sock.close()  # <- This line will raise OSError(EBADF) 
                  #    in Python 3.6 + uvloop

    loop.close()
```

The marked line (`sock.close()`) will raise `OSError` in Python 3.6 with uvloop. Why? Because uvloop passes the FD of the socket to libuv, and when the server is closed it will close the FD.

In Python 3.6, `sock.close()` will try to close the same FD, will receive an `EBADF` from the OS, and propagate the `OSError`.

This isn't strictly related to uvloop—any efficient low-level implementation of the event loop that doesn't use Python's high level `socket` and `selector` modules will have the same problem.

#### Solution

I believe the actual solution would be to modify asyncio APIs that accept sockets to detach them.  When you pass a socket object to `loop.create_server`, you are essentially saying: "asyncio, here's my socket, please start serving on it and manage it for me".

This patch does a simple thing: sockets passed to `create_server`, `create_connection`, `create_datagram_endpoint` and `connect_accepted_socket` are detached with `sock.detach()`. A new socket is constructed for the same FD and it's then used internally in asyncio. Creating a new socket for the FD is fast, we only create a new Python socket object wrapping an FD (as opposed to using `socket.dup()` which would make a sys call).