### PR TITLE
Make loop TCP APIs accept only TCP streaming sockets

### DIFF
--- a/asyncio/unix_events.py
+++ b/asyncio/unix_events.py
@@ -235,7 +235,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
             if sock is None:
                 raise ValueError('no path and sock were specified')
             if (sock.family != socket.AF_UNIX or
-                    sock.type != socket.SOCK_STREAM):
+                    not base_events._is_stream_socket(sock)):
                 raise ValueError(
                     'A UNIX Domain Stream Socket was expected, got {!r}'
                     .format(sock))
@@ -289,7 +289,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                     'path was not specified, and no sock specified')
 
             if (sock.family != socket.AF_UNIX or
-                    sock.type != socket.SOCK_STREAM):
+                    not base_events._is_stream_socket(sock)):
                 raise ValueError(
                     'A UNIX Domain Stream Socket was expected, got {!r}'
                     .format(sock))


### PR DESCRIPTION
Currently, `loop.create_server`, `loop.create_connection`, and `loop.connect_accepted_socket` accept any kind of socket, although they are documented (and used by asyncio users) as TCP API.

Allowing those methods to accept any kinds of sockets leads to hard to debug bugs.  For instance, aiohttp gunicorn worker simply passes all sockets to `create_server` (including UNIX sockets). We even have a unittest in asyncio that does that: `test_create_datagram_endpoint_sock` passes a UDP socket to `create_connection`.

TCP, UDP and UNIX sockets are different from each other and have some subtle API differences. We shouldn't allow to blindly pass any of them to `create_server` and other TCP APIs.