### PR TITLE
Fix create_unix_server to support Path-like objects (PEP 519)

### DIFF
--- a/asyncio/unix_events.py
+++ b/asyncio/unix_events.py
@@ -39,6 +39,13 @@ def _sighandler_noop(signum, frame):
     pass
 
 
+try:
+    _fspath = os.fspath
+except AttributeError:
+    # Python 3.5 or earlier
+    _fspath = lambda path: path
+
+
 class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
     """Unix event loop.
 
@@ -256,6 +263,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                 raise ValueError(
                     'path and sock can not be specified at the same time')
 
+            path = _fspath(path)
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
             # Check for abstract socket. `str` and `bytes` paths are supported.

--- a/tests/test_unix_events.py
+++ b/tests/test_unix_events.py
@@ -4,6 +4,7 @@ import collections
 import errno
 import io
 import os
+import pathlib
 import signal
 import socket
 import stat
@@ -248,6 +249,15 @@ class SelectorEventLoopUnixSocketTests(test_utils.TestCase):
 
             coro = self.loop.create_unix_server(lambda: None, path)
             srv = self.loop.run_until_complete(coro)
+            srv.close()
+            self.loop.run_until_complete(srv.wait_closed())
+
+    @unittest.skipUnless(hasattr(os, 'fspath'), 'no os.fspath')
+    def test_create_unix_server_pathlib(self):
+        with test_utils.unix_socket_path() as path:
+            path = pathlib.Path(path)
+            srv_coro = self.loop.create_unix_server(lambda: None, path)
+            srv = self.loop.run_until_complete(srv_coro)
             srv.close()
             self.loop.run_until_complete(srv.wait_closed())
 


### PR DESCRIPTION
One of the recent commits broke support of PEP 519. This PR fixes `loop.create_unix_server` to support Path-like objects + a regression test.

cc @brettcannon 