### PR TITLE
Cancelled lock waiter wakes up the next one if any

### DIFF
--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -176,6 +176,29 @@ class LockTests(test_utils.TestCase):
         self.assertTrue(tb.cancelled())
         self.assertTrue(tc.done())
 
+    def test_finished_waiter_cancelled(self):
+        lock = asyncio.Lock(loop=self.loop)
+
+        ta = asyncio.Task(lock.acquire(), loop=self.loop)
+        test_utils.run_briefly(self.loop)
+        self.assertTrue(lock.locked())
+
+        tb = asyncio.Task(lock.acquire(), loop=self.loop)
+        test_utils.run_briefly(self.loop)
+        self.assertEqual(len(lock._waiters), 1)
+
+        # Create a second waiter, wake up the first, and cancel it.
+        # Without the fix, the second was not woken up.
+        tc = asyncio.Task(lock.acquire(), loop=self.loop)
+        lock.release()
+        tb.cancel()
+        test_utils.run_briefly(self.loop)
+
+        self.assertTrue(lock.locked())
+        self.assertTrue(ta.done())
+        self.assertTrue(tb.cancelled())
+        self.assertTrue(tc.done())
+
     def test_release_not_acquired(self):
         lock = asyncio.Lock(loop=self.loop)
 

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -71,31 +71,6 @@ class LockTests(BaseTest):
             self.loop.run_until_complete(test(primitive))
             self.assertFalse(primitive.locked())
 
-    def test_finished_waiter_cancelled(self):
-
-        async def create_waiter(lock, fut):
-            fut.set_result(True)
-            async with lock:
-                pass
-
-        async def runner():
-            lock = asyncio.Lock(loop=self.loop)
-
-            await lock.acquire()
-
-            fut = self.loop.create_future()
-            task = asyncio.ensure_future(create_waiter(lock, fut),
-                                             loop=self.loop)
-            await fut
-
-            lock.release()
-            task.cancel()
-
-            async with lock:
-                pass
-
-        self.loop.run_until_complete(runner())
-
 
 class StreamReaderTests(BaseTest):
 


### PR DESCRIPTION
Fixes http://bugs.python.org/issue27585

Without the fix the unit test deadlock, I haven't managed to make it fail (using wait_for() seems to avoid the deadlock)