### PR TITLE
SSL hangs if connection_lost is called (#472)

### DIFF
--- a/asyncio/sslproto.py
+++ b/asyncio/sslproto.py
@@ -479,6 +479,7 @@ class SSLProtocol(protocols.Protocol):
             self._loop.call_soon(self._app_protocol.connection_lost, exc)
         self._transport = None
         self._app_transport = None
+        self._wakeup_waiter(exc)
 
     def pause_writing(self):
         """Called when the low-level transport's buffer goes over

--- a/tests/test_sslproto.py
+++ b/tests/test_sslproto.py
@@ -85,5 +85,15 @@ class SslProtoHandshakeTests(test_utils.TestCase):
             # Restore error logging.
             log.logger.setLevel(log_level)
 
+    def test_connection_lost(self):
+        # From issue #472.
+        # yield from waiter hang if lost_connection was called.
+        waiter = asyncio.Future(loop=self.loop)
+        ssl_proto = self.ssl_protocol(waiter)
+        self.connection_made(ssl_proto)
+        ssl_proto.connection_lost(ConnectionAbortedError)
+        test_utils.run_briefly(self.loop)
+        self.assertIsInstance(waiter.exception(), ConnectionAbortedError)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There were situations when yield from waiter hangs. For example if connection is aborted by peer before handshake completes.