### PR TITLE
Delay closing SubprocessStreamProtocol's Transport until all pipes are closed.

### DIFF
--- a/asyncio/subprocess.py
+++ b/asyncio/subprocess.py
@@ -96,9 +96,9 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
     def _maybe_close_transport(self, fd):
         if fd in self._pipe_fds:
             self._pipe_fds.remove(fd)
-            if len(self._pipe_fds) == 0:
-                self._transport.close()
-                self._transport = None
+        if len(self._pipe_fds) == 0:
+            self._transport.close()
+            self._transport = None
 
 
 class Process:

--- a/asyncio/subprocess.py
+++ b/asyncio/subprocess.py
@@ -24,6 +24,7 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
         self._limit = limit
         self.stdin = self.stdout = self.stderr = None
         self._transport = None
+        self._pipe_fds = [-1]
 
     def __repr__(self):
         info = [self.__class__.__name__]
@@ -43,12 +44,14 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
             self.stdout = streams.StreamReader(limit=self._limit,
                                                loop=self._loop)
             self.stdout.set_transport(stdout_transport)
+            self._pipe_fds.append(1)
 
         stderr_transport = transport.get_pipe_transport(2)
         if stderr_transport is not None:
             self.stderr = streams.StreamReader(limit=self._limit,
                                                loop=self._loop)
             self.stderr.set_transport(stderr_transport)
+            self._pipe_fds.append(2)
 
         stdin_transport = transport.get_pipe_transport(0)
         if stdin_transport is not None:
@@ -85,10 +88,17 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
                 reader.feed_eof()
             else:
                 reader.set_exception(exc)
+            self._maybe_close_transport(fd)
 
     def process_exited(self):
-        self._transport.close()
-        self._transport = None
+        self._maybe_close_transport(-1)
+        
+    def _maybe_close_transport(self, fd):
+        if fd in self._pipe_fds:
+            self._pipe_fds.remove(fd)
+            if len(self._pipe_fds) == 0:
+                self._transport.close()
+                self._transport = None
 
 
 class Process:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -459,6 +459,28 @@ class SubprocessMixin:
                     self.loop.run_until_complete(create)
                 self.assertEqual(warns, [])
 
+    def test_read_stdout_after_process_exit(self):
+        @asyncio.coroutine
+        def execute():
+            code = '\n'.join(['import sys, time',
+                              'for _ in range(64):',
+                              '    sys.stdout.write("x" * 4096)',
+                              'sys.stdout.flush()',
+                              'sys.exit(1)'])
+            #fut = asyncio.create_subprocess_exec('timeout', '0.1', 'cat', '/dev/urandom',
+            fut = asyncio.create_subprocess_exec(sys.executable, '-c', code,            
+                                     stdout=asyncio.subprocess.PIPE,
+                                                 loop=self.loop)
+            process = yield from fut
+            while True:
+                data = yield from process.stdout.read(65536)
+                if data:
+                    yield from asyncio.sleep(0.3, loop=self.loop)
+                else:
+                    break
+
+        self.loop.run_until_complete(execute())
+                                                
 
 if sys.platform != 'win32':
     # Unix

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -462,12 +462,12 @@ class SubprocessMixin:
     def test_read_stdout_after_process_exit(self):
         @asyncio.coroutine
         def execute():
-            code = '\n'.join(['import sys, time',
+            code = '\n'.join(['import sys',
                               'for _ in range(64):',
                               '    sys.stdout.write("x" * 4096)',
                               'sys.stdout.flush()',
                               'sys.exit(1)'])
-            #fut = asyncio.create_subprocess_exec('timeout', '0.1', 'cat', '/dev/urandom',
+
             fut = asyncio.create_subprocess_exec(sys.executable, '-c', code,            
                                      stdout=asyncio.subprocess.PIPE,
                                                  loop=self.loop)


### PR DESCRIPTION
I believe this change fixes #484.

Delays the closing for `SubprocessStreamProtocol._transport` until all pipes have been closed and the process has exited rather than just the process exiting. This allows for reading data from the subprocess that is still pending in the pipe after the process has exited.

I haven't run tests or created a test for this exact issue but I will create a few tests later.