### PR TITLE
Do not connect UDP sockets when broadcast is allowed

### DIFF
--- a/asyncio/base_events.py
+++ b/asyncio/base_events.py
@@ -916,7 +916,8 @@ class BaseEventLoop(events.AbstractEventLoop):
                     if local_addr:
                         sock.bind(local_address)
                     if remote_addr:
-                        yield from self.sock_connect(sock, remote_address)
+                        if not allow_broadcast:
+                            yield from self.sock_connect(sock, remote_address)
                         r_addr = remote_address
                 except OSError as exc:
                     if sock is not None:

--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -1083,9 +1083,11 @@ class _SelectorDatagramTransport(_SelectorTransport):
         if not data:
             return
 
-        if self._address and addr not in (None, self._address):
-            raise ValueError('Invalid address: must be None or %s' %
-                             (self._address,))
+        if self._address:
+            if addr not in (None, self._address):
+                raise ValueError(
+                    'Invalid address: must be None or %s' % (self._address,))
+            addr = self._address
 
         if self._conn_lost and self._address:
             if self._conn_lost >= constants.LOG_THRESHOLD_FOR_CONNLOST_WRITES:
@@ -1096,10 +1098,7 @@ class _SelectorDatagramTransport(_SelectorTransport):
         if not self._buffer:
             # Attempt to send it right away first.
             try:
-                if self._address:
-                    self._sock.send(data)
-                else:
-                    self._sock.sendto(data, addr)
+                self._sock.sendto(data, addr)
                 return
             except (BlockingIOError, InterruptedError):
                 self._loop._add_writer(self._sock_fd, self._sendto_ready)
@@ -1119,10 +1118,7 @@ class _SelectorDatagramTransport(_SelectorTransport):
         while self._buffer:
             data, addr = self._buffer.popleft()
             try:
-                if self._address:
-                    self._sock.send(data)
-                else:
-                    self._sock.sendto(data, addr)
+                self._sock.sendto(data, addr)
             except (BlockingIOError, InterruptedError):
                 self._buffer.appendleft((data, addr))  # Try again later.
                 break

--- a/asyncio/selector_events.py
+++ b/asyncio/selector_events.py
@@ -553,7 +553,10 @@ class _SelectorTransport(transports._FlowControlMixin,
     def __init__(self, loop, sock, protocol, extra=None, server=None):
         super().__init__(extra, loop)
         self._extra['socket'] = sock
-        self._extra['sockname'] = sock.getsockname()
+        try:
+            self._extra['sockname'] = sock.getsockname()
+        except socket.error:
+            self._extra['sockname'] = None
         if 'peername' not in self._extra:
             try:
                 self._extra['peername'] = sock.getpeername()

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -1463,6 +1463,18 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertRaises(
             OSError, self.loop.run_until_complete, coro)
 
+    def test_create_datagram_endpoint_no_connect_when_broadcast_allowed(self):
+        self.loop.sock_connect = sock_connect = mock.Mock()
+        sock_connect.return_value = []
+
+        coro = self.loop.create_datagram_endpoint(
+            asyncio.DatagramProtocol,
+            remote_addr=('127.0.0.1', 0),
+            allow_broadcast=True)
+
+        self.loop.run_until_complete(coro)
+        self.assertFalse(sock_connect.called)
+
     @patch_socket
     def test_create_datagram_endpoint_socket_err(self, m_socket):
         m_socket.getaddrinfo = socket.getaddrinfo

--- a/tests/test_base_events.py
+++ b/tests/test_base_events.py
@@ -1463,17 +1463,22 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertRaises(
             OSError, self.loop.run_until_complete, coro)
 
-    def test_create_datagram_endpoint_no_connect_when_broadcast_allowed(self):
+    def test_create_datagram_endpoint_allow_broadcast(self):
+        protocol = MyDatagramProto(create_future=True, loop=self.loop)
         self.loop.sock_connect = sock_connect = mock.Mock()
         sock_connect.return_value = []
 
         coro = self.loop.create_datagram_endpoint(
-            asyncio.DatagramProtocol,
+            lambda: protocol,
             remote_addr=('127.0.0.1', 0),
             allow_broadcast=True)
 
-        self.loop.run_until_complete(coro)
+        transport, _ = self.loop.run_until_complete(coro)
         self.assertFalse(sock_connect.called)
+
+        transport.close()
+        self.loop.run_until_complete(protocol.done)
+        self.assertEqual('CLOSED', protocol.state)
 
     @patch_socket
     def test_create_datagram_endpoint_socket_err(self, m_socket):

--- a/tests/test_selector_events.py
+++ b/tests/test_selector_events.py
@@ -1673,7 +1673,7 @@ class SelectorDatagramTransportTests(test_utils.TestCase):
     def test_sendto_error_received_connected(self):
         data = b'data'
 
-        self.sock.send.side_effect = ConnectionRefusedError
+        self.sock.sendto.side_effect = ConnectionRefusedError
 
         transport = self.datagram_transport(address=('0.0.0.0', 1))
         transport._fatal_error = mock.Mock()
@@ -1768,7 +1768,7 @@ class SelectorDatagramTransportTests(test_utils.TestCase):
         self.assertFalse(transport._fatal_error.called)
 
     def test_sendto_ready_error_received_connection(self):
-        self.sock.send.side_effect = ConnectionRefusedError
+        self.sock.sendto.side_effect = ConnectionRefusedError
 
         transport = self.datagram_transport(address=('0.0.0.0', 1))
         transport._fatal_error = mock.Mock()


### PR DESCRIPTION
This PR fixes issue #480, as explained in [this comment](https://github.com/python/asyncio/issues/480#issuecomment-278703828).

The `_SelectorDatagramTransport.sendto` method has to be modified so `_sock.sendto` is used in all cases (because there is no proper way to tell if the socket is connected or not). Could that be an
issue for connected sockets?